### PR TITLE
add: ExecutionReducers.fromParams to implement ExecutionRepository

### DIFF
--- a/src/execution-queue.ts
+++ b/src/execution-queue.ts
@@ -48,6 +48,10 @@ export const ExecutionReducers = {
   >(
     self: S,
   ): S => ({ ...self, isExecuted: true }),
+
+  fromParams: <TId, TFunc extends (this: unknown, ...args: never[]) => TReturned, TReturned>(
+    params: Omit<Execution<TId, TFunc, TReturned>, typeof executionTypeSymbol>,
+  ) => ({ [executionTypeSymbol]: executionTypeSymbol, ...params }) as const,
 };
 
 export interface ExecutionRepository<


### PR DESCRIPTION
### Changes

- Add `ExecutionReducers.fromParams` function
  - `executionTypeSymbol` is not exported from this library, so the dependents cannot implement retrieval methods in `ExecutionRepository`.
  - By this change, the dependents will be able to implement `ExecutionRepository`.