### PR TITLE
change: use functions instead of class in asyncify-events and execution-queue

### DIFF
--- a/src/asyncify-events.test.ts
+++ b/src/asyncify-events.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest, test } from '@jest/globals';
+import { clientFromPort, portFromEventTarget, startServerFromPort } from './asyncify-events.js';
+
+describe('asyncify-events', () => {
+  const delayedAdd = jest.fn(
+    (arg1: number, arg2: number) =>
+      new Promise<number>((resolve) => {
+        setTimeout(() => {
+          resolve(arg1 + arg2);
+        }, 1000);
+      }),
+  );
+
+  const clientTarget = new EventTarget();
+  const serverTarget = new EventTarget();
+
+  const clientPort = portFromEventTarget(clientTarget, serverTarget);
+  const serverPort = portFromEventTarget(serverTarget, clientTarget);
+
+  const stopServer = startServerFromPort(delayedAdd, serverPort);
+  const request = clientFromPort<typeof delayedAdd>(clientPort);
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'setInterval');
+    jest.spyOn(serverTarget, 'removeEventListener');
+  });
+
+  test('client can send a request and receive a response', async () => {
+    const resultPromise = request(1, 2);
+    jest.advanceTimersByTime(1000);
+
+    expect(resultPromise).resolves.toBe(3);
+    // Ensure that one request makes one call to the server function
+    expect(delayedAdd).toHaveBeenCalledTimes(1);
+  });
+
+  test('client and server can handle multiple requests', async () => {
+    const resultPromises = [];
+    for (let i = 0; i < 10; i += 1) {
+      const resultPromise = request(i, i + 1);
+      resultPromises.push(resultPromise);
+    }
+    jest.advanceTimersByTime(1000);
+    const results = await Promise.all(resultPromises);
+
+    results.forEach((result, index) => {
+      expect(result).toBe(index + (index + 1));
+    });
+    // Ensure that one request makes one call to the server function
+    expect(delayedAdd).toHaveBeenCalledTimes(10);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    stopServer();
+  });
+});

--- a/src/asyncify-events.test.ts
+++ b/src/asyncify-events.test.ts
@@ -81,8 +81,13 @@ describe('asyncify-events', () => {
   describe('Client: request and response handling', () => {
     const st = new EventTarget();
     const ct = new EventTarget();
-    const stopServer = startServerFromPort(addAsync, portFromEventTarget(st, ct));
-    const request = clientFromPort<typeof addAsync>(portFromEventTarget(ct, st));
+    const stopServer = startServerFromPort(
+      addAsync,
+      portFromEventTarget({ me: st, other: ct, channel: 'my-channel' }),
+    );
+    const request = clientFromPort<typeof addAsync>(
+      portFromEventTarget({ me: ct, other: st, channel: 'my-channel' }),
+    );
 
     test('client can send a request and receive a response', async () => {
       const resultPromise = request(1, 2);
@@ -117,8 +122,13 @@ describe('asyncify-events', () => {
   describe('AbortableClient: request and response handling', () => {
     const st = new EventTarget();
     const ct = new EventTarget();
-    const stopServer = startAbortableServerFromPort(abortableAddAsync, portFromEventTarget(st, ct));
-    const request = abortableClientFromPort<typeof abortableAddAsync>(portFromEventTarget(ct, st));
+    const stopServer = startAbortableServerFromPort(
+      abortableAddAsync,
+      portFromEventTarget({ me: st, other: ct, channel: 'my-channel' }),
+    );
+    const request = abortableClientFromPort<typeof abortableAddAsync>(
+      portFromEventTarget({ me: ct, other: st, channel: 'my-channel' }),
+    );
 
     test('client can send a request and receive a response', async () => {
       const resultPromise = request([1, 2]);
@@ -172,8 +182,13 @@ describe('asyncify-events', () => {
   describe('Client: request and error handling', () => {
     const st = new EventTarget();
     const ct = new EventTarget();
-    const stopServer = startServerFromPort(rejectAsync, portFromEventTarget(st, ct));
-    const request = clientFromPort<typeof rejectAsync>(portFromEventTarget(ct, st));
+    const stopServer = startServerFromPort(
+      rejectAsync,
+      portFromEventTarget({ me: st, other: ct, channel: 'my-channel' }),
+    );
+    const request = clientFromPort<typeof rejectAsync>(
+      portFromEventTarget({ me: ct, other: st, channel: 'my-channel' }),
+    );
 
     test('client can handle a request and receive an error', async () => {
       expect(request()).rejects.toThrowError('Error');
@@ -189,10 +204,10 @@ describe('asyncify-events', () => {
     const ct = new EventTarget();
     const stopServer = startAbortableServerFromPort(
       abortableRejectAsync,
-      portFromEventTarget(st, ct),
+      portFromEventTarget({ me: st, other: ct, channel: 'my-channel' }),
     );
     const request = abortableClientFromPort<typeof abortableRejectAsync>(
-      portFromEventTarget(ct, st),
+      portFromEventTarget({ me: ct, other: st, channel: 'my-channel' }),
     );
 
     test('client can handle a request and receive an error', async () => {
@@ -207,8 +222,11 @@ describe('asyncify-events', () => {
   describe('AbortableClient: lifecycle management', () => {
     const st = new EventTarget();
     const ct = new EventTarget();
-    const clientPort = portFromEventTarget(ct, st);
-    const stopServer = startAbortableServerFromPort(add, portFromEventTarget(st, ct));
+    const clientPort = portFromEventTarget({ me: ct, other: st, channel: 'my-channel' });
+    const stopServer = startAbortableServerFromPort(
+      add,
+      portFromEventTarget({ me: st, other: ct, channel: 'my-channel' }),
+    );
     const request = abortableClientFromPort<typeof add>(clientPort);
 
     test('response handler is stopped if unnecessary', async () => {

--- a/src/asyncify-events.test.ts
+++ b/src/asyncify-events.test.ts
@@ -1,8 +1,14 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, jest, test } from '@jest/globals';
-import { clientFromPort, portFromEventTarget, startServerFromPort } from './asyncify-events.js';
+import { afterAll, afterEach, beforeAll, describe, expect, jest, test } from '@jest/globals';
+import {
+  abortableClientFromPort,
+  clientFromPort,
+  portFromEventTarget,
+  startAbortableServerFromPort,
+  startServerFromPort,
+} from './asyncify-events.js';
 
 describe('asyncify-events', () => {
-  const delayedAdd = jest.fn(
+  const addAsync = jest.fn(
     (arg1: number, arg2: number) =>
       new Promise<number>((resolve) => {
         setTimeout(() => {
@@ -11,53 +17,230 @@ describe('asyncify-events', () => {
       }),
   );
 
-  const clientTarget = new EventTarget();
-  const serverTarget = new EventTarget();
+  const abortableAddAsync = jest.fn(
+    (args: [number, number], abortSignal?: AbortSignal) =>
+      new Promise<number>((resolve, reject) => {
+        const handleAbort = (event: Event) => {
+          clearTimeout(timeout);
+          reject(
+            new Error(
+              event?.currentTarget instanceof AbortSignal ? event.currentTarget.reason : 'Aborted',
+            ),
+          );
+        };
 
-  const clientPort = portFromEventTarget(clientTarget, serverTarget);
-  const serverPort = portFromEventTarget(serverTarget, clientTarget);
+        abortSignal?.addEventListener('abort', handleAbort, { once: true });
 
-  const stopServer = startServerFromPort(delayedAdd, serverPort);
-  const request = clientFromPort<typeof delayedAdd>(clientPort);
+        const timeout = setTimeout(() => {
+          resolve(args[0] + args[1]);
+          abortSignal?.removeEventListener('abort', handleAbort);
+        }, 1000);
+      }),
+  );
+
+  const rejectAsync = jest.fn(
+    () =>
+      new Promise<number>((resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error('Error'));
+        }, 1000);
+      }),
+  );
+
+  const abortableRejectAsync = jest.fn(
+    (args: [], abortSignal?: AbortSignal) =>
+      new Promise<number>((resolve, reject) => {
+        const handleAbort = (event: Event) => {
+          clearTimeout(timeout);
+          reject(
+            new Error(
+              event?.currentTarget instanceof AbortSignal ? event.currentTarget.reason : 'Aborted',
+            ),
+          );
+        };
+
+        abortSignal?.addEventListener('abort', handleAbort, { once: true });
+
+        const timeout = setTimeout(() => {
+          reject(new Error('Error'));
+          abortSignal?.removeEventListener('abort', handleAbort);
+        }, 1000);
+      }),
+  );
+
+  const add = jest.fn((args: [number, number], abortSignal?: AbortSignal) => {
+    return args[0] + args[1];
+  });
 
   beforeAll(() => {
     jest.useFakeTimers();
     jest.spyOn(global, 'setTimeout');
     jest.spyOn(global, 'setInterval');
-    jest.spyOn(serverTarget, 'removeEventListener');
   });
 
-  test('client can send a request and receive a response', async () => {
-    const resultPromise = request(1, 2);
-    jest.advanceTimersByTime(1000);
+  describe('Client: request and response handling', () => {
+    const st = new EventTarget();
+    const ct = new EventTarget();
+    const stopServer = startServerFromPort(addAsync, portFromEventTarget(st, ct));
+    const request = clientFromPort<typeof addAsync>(portFromEventTarget(ct, st));
 
-    expect(resultPromise).resolves.toBe(3);
-    // Ensure that one request makes one call to the server function
-    expect(delayedAdd).toHaveBeenCalledTimes(1);
-  });
+    test('client can send a request and receive a response', async () => {
+      const resultPromise = request(1, 2);
+      jest.advanceTimersByTime(1000);
 
-  test('client and server can handle multiple requests', async () => {
-    const resultPromises = [];
-    for (let i = 0; i < 10; i += 1) {
-      const resultPromise = request(i, i + 1);
-      resultPromises.push(resultPromise);
-    }
-    jest.advanceTimersByTime(1000);
-    const results = await Promise.all(resultPromises);
-
-    results.forEach((result, index) => {
-      expect(result).toBe(index + (index + 1));
+      expect(resultPromise).resolves.toBe(3);
+      // Ensure that one request makes one call to the server function
+      expect(addAsync).toHaveBeenCalledTimes(1);
     });
-    // Ensure that one request makes one call to the server function
-    expect(delayedAdd).toHaveBeenCalledTimes(10);
+
+    test('client and server can handle multiple requests', async () => {
+      const resultPromises = [];
+      for (let i = 0; i < 10; i += 1) {
+        const resultPromise = request(i, i + 1);
+        resultPromises.push(resultPromise);
+      }
+      jest.advanceTimersByTime(1000);
+      const results = await Promise.all(resultPromises);
+
+      results.forEach((result, index) => {
+        expect(result).toBe(index + (index + 1));
+      });
+      // Ensure that one request makes one call to the server function
+      expect(addAsync).toHaveBeenCalledTimes(10);
+    });
+
+    afterAll(() => {
+      stopServer();
+    });
+  });
+
+  describe('AbortableClient: request and response handling', () => {
+    const st = new EventTarget();
+    const ct = new EventTarget();
+    const stopServer = startAbortableServerFromPort(abortableAddAsync, portFromEventTarget(st, ct));
+    const request = abortableClientFromPort<typeof abortableAddAsync>(portFromEventTarget(ct, st));
+
+    test('client can send a request and receive a response', async () => {
+      const resultPromise = request([1, 2]);
+      jest.advanceTimersByTime(1000);
+
+      expect(resultPromise).resolves.toBe(3);
+      // Ensure that one request makes one call to the server function
+      expect(abortableAddAsync).toHaveBeenCalledTimes(1);
+    });
+
+    test('client can handle abortSignal from the user', () => {
+      const abortController = new AbortController();
+      const resultPromise = request([1, 2], abortController.signal);
+      abortController.abort('Custom abort reason');
+
+      expect(resultPromise).rejects.toThrowError('Custom abort reason');
+    });
+
+    test('client can handle multiple abortSignal from the user', () => {
+      const promises = [];
+      for (let i = 0; i < 10; i += 1) {
+        const abortController = new AbortController();
+        const resultPromise = request([i, i + 1], abortController.signal);
+        promises.push(resultPromise);
+        if (i % 2 === 0) {
+          abortController.abort('Custom abort reason');
+        }
+      }
+
+      Promise.allSettled(promises).then((results) => {
+        results.forEach((result, i) => {
+          if (i % 2 === 0 && result.status === 'rejected') {
+            expect(result.reason).toBeInstanceOf(Error);
+            expect(result.reason).toHaveProperty('message', 'Custom abort reason');
+          } else if (i % 2 === 1 && result.status === 'fulfilled') {
+            expect(result.value).toBe(i + (i + 1));
+          } else {
+            throw new Error('Unexpected result status');
+          }
+        });
+      });
+      // Ensure that one request makes one call to the server function
+      expect(abortableAddAsync).toHaveBeenCalledTimes(10);
+    });
+
+    afterAll(() => {
+      stopServer();
+    });
+  });
+
+  describe('Client: request and error handling', () => {
+    const st = new EventTarget();
+    const ct = new EventTarget();
+    const stopServer = startServerFromPort(rejectAsync, portFromEventTarget(st, ct));
+    const request = clientFromPort<typeof rejectAsync>(portFromEventTarget(ct, st));
+
+    test('client can handle a request and receive an error', async () => {
+      expect(request()).rejects.toThrowError('Error');
+    });
+
+    afterAll(() => {
+      stopServer();
+    });
+  });
+
+  describe('AbortableClient: request and error handling', () => {
+    const st = new EventTarget();
+    const ct = new EventTarget();
+    const stopServer = startAbortableServerFromPort(
+      abortableRejectAsync,
+      portFromEventTarget(st, ct),
+    );
+    const request = abortableClientFromPort<typeof abortableRejectAsync>(
+      portFromEventTarget(ct, st),
+    );
+
+    test('client can handle a request and receive an error', async () => {
+      expect(request([])).rejects.toThrowError('Error');
+    });
+
+    afterAll(() => {
+      stopServer();
+    });
+  });
+
+  describe('AbortableClient: lifecycle management', () => {
+    const st = new EventTarget();
+    const ct = new EventTarget();
+    const clientPort = portFromEventTarget(ct, st);
+    const stopServer = startAbortableServerFromPort(add, portFromEventTarget(st, ct));
+    const request = abortableClientFromPort<typeof add>(clientPort);
+
+    test('response handler is stopped if unnecessary', async () => {
+      jest.spyOn(clientPort, 'listen');
+
+      const result1 = await request([1, 2]);
+      expect(result1).toBe(3);
+      expect(clientPort.listen).toBeCalledTimes(1);
+
+      // この時点で1回目のリクエストに対するレスポンスは処理済みなので、待機中のレスポンスが無くなり、レスポンスをlistenする必要はなくなる。
+      // 2回目のリクエストを送信すると、再度レスポンスをlistenする必要が生じるので、clientPort.listenが再度呼び出される。
+      const result2 = await request([1, 2]);
+      expect(result2).toBe(3);
+      expect(clientPort.listen).toBeCalledTimes(2);
+    });
+
+    test('abort handler is removed after the request is resolved', async () => {
+      const abortController = new AbortController();
+      jest.spyOn(abortController.signal, 'addEventListener');
+      jest.spyOn(abortController.signal, 'removeEventListener');
+      await request([1, 2], abortController.signal);
+      expect(abortController.signal.addEventListener).toBeCalledTimes(1);
+      expect(abortController.signal.removeEventListener).toBeCalledTimes(1);
+    });
+
+    afterAll(() => {
+      stopServer();
+    });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
-  });
-
-  afterAll(() => {
-    stopServer();
   });
 });

--- a/src/asyncify-events.ts
+++ b/src/asyncify-events.ts
@@ -241,25 +241,14 @@ export const abortableClientFromPort = <
  *
  * @returns A function that can be called to stop the server.
  */
-export const startServerFromPort = <
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
->(
-  func: TFunc,
+export const startServerFromPort = <TArgs extends unknown[], TReturned>(
+  func: (this: unknown, ...args: TArgs) => TReturned,
   port: AsyncifyEventsPort,
 ): (() => void) =>
-  startAbortableServerFromPort<AbortableFunction<TArgs, TReturned>, TArgs, TReturned>(
-    (args: TArgs) => func(...args),
-    port,
-  );
+  startAbortableServerFromPort<TArgs, TReturned>((args: TArgs) => func(...args), port);
 
-export const startAbortableServerFromPort = <
-  TFunc extends AbortableFunction<TArgs, TReturned>,
-  TArgs extends unknown[] = Parameters<TFunc>[0],
-  TReturned = ReturnType<TFunc>,
->(
-  func: TFunc,
+export const startAbortableServerFromPort = <TArgs extends unknown[], TReturned>(
+  func: AbortableFunction<TArgs, TReturned>,
   port: AsyncifyEventsPort,
 ): (() => void) => {
   const abortControllers = new Map<Request<TArgs>['id'], AbortController>();
@@ -292,22 +281,33 @@ export const startAbortableServerFromPort = <
   return port.listen<Request<TArgs> | AbortRequest>(requestRouter);
 };
 
-export const portFromEventTarget = (me: EventTarget, other: EventTarget): AsyncifyEventsPort => ({
+/** @internal */
+export type PortMessage<TBody> = { readonly channel: string; readonly body: TBody };
+
+export const portFromEventTarget = (params: {
+  readonly me: EventTarget;
+  readonly other: EventTarget;
+  readonly channel: string;
+}): AsyncifyEventsPort => ({
   send: <TRequest>(request: TRequest) => {
-    other.dispatchEvent(new MessageEvent('message', { data: request }));
+    const detail = { body: request, channel: params.channel } satisfies PortMessage<TRequest>;
+    params.other.dispatchEvent(new CustomEvent<PortMessage<TRequest>>('message', { detail }));
   },
 
   listen: <TResponse>(handleResponse: (this: unknown, response: TResponse) => void) => {
-    const handleMessage = (event: Event | MessageEvent<TResponse>) => {
-      if (event instanceof MessageEvent) {
-        handleResponse(event.data as TResponse);
+    const handleMessage = (event: Event | CustomEvent<PortMessage<TResponse>>) => {
+      if (
+        event instanceof CustomEvent &&
+        (event as CustomEvent<PortMessage<TResponse>>).detail.channel === params.channel
+      ) {
+        handleResponse((event as CustomEvent<PortMessage<TResponse>>).detail.body);
       }
     };
 
-    me.addEventListener('message', handleMessage);
+    params.me.addEventListener('message', handleMessage);
 
     return () => {
-      me.removeEventListener('message', handleMessage);
+      params.me.removeEventListener('message', handleMessage);
     };
   },
 });
@@ -323,13 +323,17 @@ export const portFromMessagePort = (
   channel: string,
 ): AsyncifyEventsPort => ({
   send: <TRequest>(request: TRequest) => {
-    messagePort.postMessage({ channel, body: request });
+    const data = { channel, body: request } satisfies PortMessage<TRequest>;
+    messagePort.postMessage(data);
   },
 
   listen: <TResponse>(handleResponse: (this: unknown, response: TResponse) => void) => {
-    const handleMessage = (event: Event | MessageEvent<TResponse>) => {
-      if (event instanceof MessageEvent && event.data.channel === channel) {
-        handleResponse(event.data.body as TResponse);
+    const handleMessage = (event: Event | MessageEvent<PortMessage<TResponse>>) => {
+      if (
+        event instanceof MessageEvent &&
+        (event as MessageEvent<PortMessage<TResponse>>).data.channel === channel
+      ) {
+        handleResponse((event as MessageEvent<PortMessage<TResponse>>).data.body);
       }
     };
 

--- a/src/asyncify-events.ts
+++ b/src/asyncify-events.ts
@@ -3,11 +3,7 @@ import { type Id, generateId } from './random-values.js';
 
 const messageTypeSymbol = Symbol();
 
-interface Request<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> {
+interface Request<TArgs extends unknown[]> {
   readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
   readonly args: Readonly<TArgs>;
 }
@@ -17,251 +13,189 @@ interface Response<TReturned> {
   readonly returned: TReturned;
 }
 
+type AsyncifyEventsPort = {
+  send<TRequest>(this: unknown, request: TRequest): void;
+  listen<TResponse>(
+    this: unknown,
+    handleResponse: (this: unknown, response: TResponse) => void,
+  ): () => void;
+};
+
+export type Client<
+  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
+  TArgs extends unknown[] = Parameters<TFunc>,
+  TReturned = ReturnType<TFunc>,
+> = (...args: Readonly<TArgs>) => Promise<Awaited<TReturned>>;
+
 /**
- * A client that can be used to call functions on a {@linkcode Server}.
+ * Returns a {@linkcode Client} function that can be used to call functions on a server.
  *
  * ## Example (Web Worker as a Server)
  *
  * ### Web Worker side
  *
  * ```ts
+ * import { startServerFromPort, portFromMessagePort } from '@mgn901/mgn901-utils-ts/asyncify-events';
+ *
  * // define a function
  * export const add = (arg1: number, arg2: number) => arg1 + arg2;
  *
  * // setup a server
- * export const server = new Server({
- *   terminal: new MessagePortTerminal({ port: globalThis, channel: 'my-channel' }),
- *   func: add,
- * });
+ * startServerFromPort(add, portFromMessagePort(globalThis, 'my-channel'));
  * ```
  *
  * ### Window side
  *
  * ```ts
- * import { Client, MessagePortTerminal } from '@mgn901/mgn901-utils-ts/asyncify-events';
- * import type { server } from './worker.js';
- *
- * // setup a client
- * const worker = new Worker('worker.js');
- * const client = new Client<typeof server>({
- *   terminal: new MessagePortTerminal({ port: worker, channel: 'my-channel' }),
- * });
- *
- * // call a function on the server
- * client.request(1, 2).then((result) => {
- *   console.log(result); // => 3
- * });
- * ```
- */
-export class Client<
-  TServer extends Server<TFunc, TArgs, TReturned>,
-  TArgs extends unknown[] = TServer extends Server<infer IFunc, infer IArgs, infer IReturned>
-    ? IArgs
-    : unknown,
-  TReturned = TServer extends Server<infer IFunc, TArgs, infer IReturned> ? IReturned : unknown,
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned = TServer extends Server<
-    infer IFunc,
-    TArgs,
-    TReturned
-  >
-    ? IFunc extends (this: unknown, ...args: TArgs) => TReturned
-      ? IFunc
-      : (this: unknown, ...args: TArgs) => TReturned
-    : (this: unknown, ...args: TArgs) => TReturned,
-> {
-  private readonly terminal: Terminal<Request<TFunc, TArgs, TReturned>, Response<TReturned>>;
-  private readonly responseHandlers: Map<
-    Request<TFunc, TArgs, TReturned>['id'],
-    (returned: TReturned) => void | Promise<void>
-  >;
-
-  /**
-   * Calls a function on the server.
-   * @param args The arguments to pass to the function.
-   * @returns A promise that resolves to the returned value of the function.
-   */
-  public async request<T extends Client<TServer, TArgs, TReturned, TFunc>>(
-    this: T,
-    ...args: Readonly<TArgs>
-  ): Promise<TReturned> {
-    const request: Request<TFunc, TArgs, TReturned> = {
-      id: generateId() as Request<TFunc, TArgs, TReturned>['id'],
-      args,
-    };
-    this.terminal.post(request);
-    return new Promise<TReturned>((resolve, reject) => {
-      this.responseHandlers.set(request.id, resolve);
-    });
-  }
-
-  /**
-   * Creates a new {@linkcode Client} instance.
-   * @param params Configures the created client instance.
-   */
-  public constructor(params: {
-    /** Specifies a {@linkcode Terminal} that will be used to communicate with the {@linkcode Server} on the other side. */
-    readonly terminal: Terminal<Request<TFunc, TArgs, TReturned>, Response<TReturned>>;
-  }) {
-    this.terminal = params.terminal;
-    this.responseHandlers = new Map();
-
-    this.terminal.addListener((response) => {
-      const responseHandler = this.responseHandlers.get(response.id);
-      if (responseHandler !== undefined) {
-        responseHandler(response.returned);
-        this.responseHandlers.delete(response.id);
-      }
-    });
-  }
-}
-
-/**
- * A server that can be used to handle function calls from a {@linkcode Client}.
- *
- * ## Example (Web Worker as a Server)
- *
- * ### Web Worker side
- *
- * ```ts
- * // define a function
- * export const add = (arg1: number, arg2: number) => arg1 + arg2;
- *
- * // setup a server
- * const server = new Server({
- *   terminal: new MessagePortTerminal({ port: globalThis, channel: 'my-channel' }),
- *   func: add,
- * });
- * ```
- *
- * ### Window side
- *
- * ```ts
- * import { Client, MessagePortTerminal } from '@mgn901/mgn901-utils-ts/asyncify-events';
+ * import { clientFromPort, portFromMessagePort } from '@mgn901/mgn901-utils-ts/asyncify-events';
  * import type { add } from './worker.js';
  *
  * // setup a client
  * const worker = new Worker('worker.js');
- * const client = new Client<typeof add>({
- *   terminal: new MessagePortTerminal({ port: worker, channel: 'my-channel' }),
- * });
+ * const request = clientFromPort<typeof add>(
+ *   portFromMessagePort(worker, 'my-channel')
+ * );
  *
- * // call a function on the server
- * client.request(1, 2).then((result) => {
+ * // call a function on the worker
+ * request(1, 2).then((result) => {
  *   console.log(result); // => 3
  * });
  * ```
  */
-export class Server<
+export const clientFromPort = <
   TFunc extends (this: unknown, ...args: TArgs) => TReturned,
   TArgs extends unknown[] = Parameters<TFunc>,
   TReturned = ReturnType<TFunc>,
-> {
-  private readonly terminal: Terminal<Response<TReturned>, Request<TFunc, TArgs, TReturned>>;
+>(
+  port: AsyncifyEventsPort,
+): Client<TFunc, TArgs, TReturned> => {
+  const pendingCallbacks = new Map<
+    Request<TArgs>['id'],
+    [resolve: (response: Awaited<TReturned>) => void, reject: (error: Error) => void]
+  >();
 
-  /**
-   * Creates a new {@linkcode Server} instance.
-   * @param params Configures the created server instance.
-   */
-  public constructor(params: {
-    /** Specifies a {@linkcode Terminal} that will be used to communicate with the {@linkcode Client} on the other side. */
-    readonly terminal: Terminal<Response<TReturned>, Request<TFunc, TArgs, TReturned>>;
-    /** Specifies a function that will be called when a request is received. */
-    readonly func: TFunc;
-  }) {
-    this.terminal = params.terminal;
+  let suspend: (() => void) | undefined;
 
-    this.terminal.addListener(async (request) => {
-      const returned = await params.func(...request.args);
-      this.terminal.post({ id: request.id, returned: returned });
+  const handleAllResponses = (response: Response<Awaited<TReturned>>): void => {
+    const item = pendingCallbacks.get(response.id);
+    pendingCallbacks.delete(response.id);
+    item?.[0](response.returned);
+    if (pendingCallbacks.size === 0) {
+      suspend?.();
+      suspend = undefined;
+    }
+  };
+
+  return (...args) => {
+    if (suspend === undefined) {
+      suspend = port.listen<Response<Awaited<TReturned>>>(handleAllResponses);
+    }
+
+    const request = { id: generateId() as Request<TArgs>['id'], args } satisfies Request<TArgs>;
+    const promise = new Promise<Awaited<TReturned>>((resolve, reject) => {
+      pendingCallbacks.set(request.id, [resolve, reject]);
+      port.send(request);
     });
-  }
-}
+
+    return promise;
+  };
+};
 
 /**
- * A terminal that can be used to communicate between a {@linkcode Client} and a {@linkcode Server}.
+ * Start a server that can be used to handle function calls from a {@linkcode Client}.
+ *
+ * ## Example (Web Worker as a Server)
+ *
+ * ### Web Worker side
+ *
+ * ```ts
+ * import { startServerFromPort, portFromMessagePort } from '@mgn901/mgn901-utils-ts/asyncify-events';
+ *
+ * // define a function
+ * export const add = (arg1: number, arg2: number) => arg1 + arg2;
+ *
+ * // setup a server
+ * startServerFromPort(add, portFromMessagePort(globalThis, 'my-channel'));
+ * ```
+ *
+ * ### Window side
+ *
+ * ```ts
+ * import { clientFromPort, portFromMessagePort } from '@mgn901/mgn901-utils-ts/asyncify-events';
+ * import type { add } from './worker.js';
+ *
+ * // setup a client
+ * const worker = new Worker('worker.js');
+ * const request = clientFromPort<typeof add>(
+ *   portFromMessagePort(worker, 'my-channel')
+ * );
+ *
+ * // call a function on the worker
+ * request(1, 2).then((result) => {
+ *   console.log(result); // => 3
+ * });
+ * ```
+ *
+ * @returns A function that can be called to stop the server.
  */
-export interface Terminal<TRequest, TResponse> {
-  /** @internal This is used by {@linkcode Client} instances to send messages. */
-  post(this: Terminal<TRequest, TResponse>, request: TRequest): void;
+export const startServerFromPort = <
+  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
+  TArgs extends unknown[] = Parameters<TFunc>,
+  TReturned = ReturnType<TFunc>,
+>(
+  func: TFunc,
+  port: AsyncifyEventsPort,
+): (() => void) =>
+  port.listen<Request<TArgs>>(async (request) => {
+    const returned = await func(...request.args);
+    port.send<Response<TReturned>>({ id: request.id, returned });
+  });
 
-  /** @internal This is used by {@linkcode Server} instances to receive messages. */
-  addListener(
-    this: Terminal<TRequest, TResponse>,
-    handleResponse: (this: unknown, response: TResponse) => void,
-  ): void;
-}
+export const portFromEventTarget = (me: EventTarget, other: EventTarget): AsyncifyEventsPort => ({
+  send: <TRequest>(request: TRequest) => {
+    other.dispatchEvent(new MessageEvent('message', { data: request }));
+  },
 
-/**
- * An implementation of {@linkcode Terminal} that uses the `EventTarget` interface to communicate.
- */
-export class EventTargetTerminal<TRequest, TResponse> implements Terminal<TRequest, TResponse> {
-  private readonly me: EventTarget;
-  private readonly destination: EventTarget;
-
-  public post(this: EventTargetTerminal<TRequest, TResponse>, request: TRequest): void {
-    this.destination.dispatchEvent(new MessageEvent('message', { data: request }));
-  }
-
-  public addListener(
-    this: EventTargetTerminal<TRequest, TResponse>,
-    handleResponse: (this: unknown, response: TResponse) => void,
-  ): void {
+  listen: <TResponse>(handleResponse: (this: unknown, response: TResponse) => void) => {
     const handleMessage = (event: Event | MessageEvent<TResponse>) => {
       if (event instanceof MessageEvent) {
         handleResponse(event.data as TResponse);
       }
     };
 
-    this.me.addEventListener('message', handleMessage);
-  }
+    me.addEventListener('message', handleMessage);
 
-  public constructor(params: { readonly me: EventTarget; readonly destination: EventTarget }) {
-    this.me = params.me;
-    this.destination = params.destination;
-  }
-}
+    return () => {
+      me.removeEventListener('message', handleMessage);
+    };
+  },
+});
 
-/**
- * An implementation of {@linkcode Terminal} that uses the `BroadcastChannel`-like interface to communicate.
- */
-export class MessagePortTerminal<TRequest, TResponse> implements Terminal<TRequest, TResponse> {
-  private readonly port:
+export const portFromMessagePort = (
+  messagePort:
     | BroadcastChannel
     | DedicatedWorkerGlobalScope
     | MessagePort
     | ServiceWorker
     | Window
-    | Worker;
-  private readonly channel: string;
+    | Worker,
+  channel: string,
+): AsyncifyEventsPort => ({
+  send: <TRequest>(request: TRequest) => {
+    messagePort.postMessage({ channel, body: request });
+  },
 
-  public post(this: MessagePortTerminal<TRequest, TResponse>, request: TRequest): void {
-    this.port.postMessage({ channel: this.channel, body: request });
-  }
-
-  public addListener(
-    this: MessagePortTerminal<TRequest, TResponse>,
-    handleResponse: (response: TResponse) => void,
-  ): void {
+  listen: <TResponse>(handleResponse: (this: unknown, response: TResponse) => void) => {
     const handleMessage = (event: Event | MessageEvent<TResponse>) => {
-      if (event instanceof MessageEvent && event.data.channel === this.channel) {
+      if (event instanceof MessageEvent && event.data.channel === channel) {
         handleResponse(event.data.body as TResponse);
       }
     };
 
-    this.port.addEventListener('message', handleMessage);
-  }
+    messagePort.addEventListener('message', handleMessage);
 
-  public constructor(params: {
-    readonly port:
-      | BroadcastChannel
-      | DedicatedWorkerGlobalScope
-      | MessagePort
-      | ServiceWorker
-      | Window
-      | Worker;
-    readonly channel: string;
-  }) {
-    this.port = params.port;
-    this.channel = params.channel;
-  }
-}
+    return () => {
+      messagePort.removeEventListener('message', handleMessage);
+    };
+  },
+});

--- a/src/asyncify-events.ts
+++ b/src/asyncify-events.ts
@@ -22,14 +22,14 @@ type AbortRequest = {
 type Response<TReturned> = {
   readonly type: 'response';
   readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
-  readonly returned: TReturned;
+  readonly value: TReturned;
 };
 
 /** @internal */
 type ErrorResponse = {
   readonly type: 'errorResponse';
   readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
-  readonly returned: unknown;
+  readonly value: unknown;
 };
 
 export type AbortableFunction<TArgs extends unknown[], TReturned> = (
@@ -161,9 +161,9 @@ export const abortableClientFromPort = <
     // resolve/rejectを呼び出す。
     const callback = pendingCallbacks.get(response.id);
     if (response.type === 'errorResponse') {
-      callback?.[1](response.returned);
+      callback?.[1](response.value);
     } else {
-      callback?.[0](response.returned);
+      callback?.[0](response.value);
     }
 
     // resolve/rejectとリクエストIDの紐付けを解除する。
@@ -258,9 +258,9 @@ export const startAbortableServerFromPort = <TArgs extends unknown[], TReturned>
     abortControllers.set(request.id, abortController);
     try {
       const returned = await func(request.args, abortController.signal);
-      port.send<Response<TReturned>>({ type: 'response', id: request.id, returned });
+      port.send<Response<TReturned>>({ type: 'response', id: request.id, value: returned });
     } catch (error: unknown) {
-      port.send<ErrorResponse>({ type: 'errorResponse', id: request.id, returned: error });
+      port.send<ErrorResponse>({ type: 'errorResponse', id: request.id, value: error });
     } finally {
       abortControllers.delete(request.id);
     }

--- a/src/asyncify-events.ts
+++ b/src/asyncify-events.ts
@@ -1,19 +1,44 @@
 import type { NominalPrimitive } from './nominal-primitive.type';
 import { type Id, generateId } from './random-values.js';
+import { defineRouter } from './router-utils.js';
 
 const messageTypeSymbol = Symbol();
 
-interface Request<TArgs extends unknown[]> {
+/** @internal */
+type Request<TArgs extends unknown[]> = {
+  readonly type: 'request';
   readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
   readonly args: Readonly<TArgs>;
-}
+};
 
-interface Response<TReturned> {
+/** @internal */
+type AbortRequest = {
+  readonly type: 'abortRequest';
+  readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
+  readonly reason: unknown;
+};
+
+/** @internal */
+type Response<TReturned> = {
+  readonly type: 'response';
   readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
   readonly returned: TReturned;
-}
+};
 
-type AsyncifyEventsPort = {
+/** @internal */
+type ErrorResponse = {
+  readonly type: 'errorResponse';
+  readonly id: NominalPrimitive<Id, typeof messageTypeSymbol>;
+  readonly returned: unknown;
+};
+
+export type AbortableFunction<TArgs extends unknown[], TReturned> = (
+  this: unknown,
+  args: TArgs,
+  abortSignal?: AbortSignal,
+) => TReturned;
+
+export type AsyncifyEventsPort = {
   send<TRequest>(this: unknown, request: TRequest): void;
   listen<TResponse>(
     this: unknown,
@@ -26,6 +51,12 @@ export type Client<
   TArgs extends unknown[] = Parameters<TFunc>,
   TReturned = ReturnType<TFunc>,
 > = (...args: Readonly<TArgs>) => Promise<Awaited<TReturned>>;
+
+export type AbortableClient<
+  TFunc extends AbortableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = ReturnType<TFunc>,
+> = (args: Readonly<TArgs>, abortSignal?: AbortSignal) => Promise<Awaited<TReturned>>;
 
 /**
  * Returns a {@linkcode Client} function that can be used to call functions on a server.
@@ -69,35 +100,107 @@ export const clientFromPort = <
 >(
   port: AsyncifyEventsPort,
 ): Client<TFunc, TArgs, TReturned> => {
+  const underlyingAbortableClient = abortableClientFromPort<
+    AbortableFunction<TArgs, TReturned>,
+    TArgs,
+    TReturned
+  >(port);
+
+  // underlyingAbortableClientをAbortableClient未指定で呼び出す。
+  return (...args) => underlyingAbortableClient(args);
+};
+
+export const abortableClientFromPort = <
+  TFunc extends AbortableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = ReturnType<TFunc>,
+>(
+  port: AsyncifyEventsPort,
+): AbortableClient<TFunc, TArgs, TReturned> => {
   const pendingCallbacks = new Map<
     Request<TArgs>['id'],
-    [resolve: (response: Awaited<TReturned>) => void, reject: (error: Error) => void]
+    [resolve: (response: Awaited<TReturned>) => void, reject: (error: unknown) => void]
   >();
+  const requestIdAbortSignalMap = new Map<Request<TArgs>['id'], AbortSignal>();
+  const abortSignalRequestIdMap = new Map<AbortSignal, Request<TArgs>['id']>();
 
-  let suspend: (() => void) | undefined;
+  let unlisten: (() => void) | undefined;
 
-  const handleAllResponses = (response: Response<Awaited<TReturned>>): void => {
-    const item = pendingCallbacks.get(response.id);
+  // Client側のすべてのAbortSignalのabortイベントを処理する関数を定義する。
+  const handleAllAbortEvents = (event: Event): void => {
+    if (event.currentTarget instanceof AbortSignal === false) {
+      return;
+    }
+
+    // AbortSignalから元のリクエストのIDを取得する。
+    const id = abortSignalRequestIdMap.get(event.currentTarget);
+    if (id === undefined) {
+      return;
+    }
+
+    // ServerにAbortRequestを送信する。
+    port.send<AbortRequest>({ type: 'abortRequest', id, reason: event.currentTarget.reason });
+
+    // AbortSignalとリクエストIDの紐付けを解除する。
+    // AbortRequest送信後にServerがエラーを吐く可能性があるので、resolve/rejectとリクエストIDの紐付けの解除はしない。
+    requestIdAbortSignalMap.delete(id);
+    abortSignalRequestIdMap.delete(event.currentTarget);
+  };
+
+  // ServerからのすべてのResponseを処理する関数を定義する。
+  const handleAllResponses = (response: Response<Awaited<TReturned>> | ErrorResponse): void => {
+    // AbortSignalとリクエストIDの紐付けを解除する。
+    const abortSignal = requestIdAbortSignalMap.get(response.id);
+    if (abortSignal !== undefined) {
+      // リクエスト処理時に追加したAbortSignalのabortイベントリスナーも忘れずに削除する。
+      abortSignal.removeEventListener('abort', handleAllAbortEvents);
+      requestIdAbortSignalMap.delete(response.id);
+      abortSignalRequestIdMap.delete(abortSignal);
+    }
+
+    // resolve/rejectを呼び出す。
+    const callback = pendingCallbacks.get(response.id);
+    if (response.type === 'errorResponse') {
+      callback?.[1](response.returned);
+    } else {
+      callback?.[0](response.returned);
+    }
+
+    // resolve/rejectとリクエストIDの紐付けを解除する。
     pendingCallbacks.delete(response.id);
-    item?.[0](response.returned);
+
+    // Response待ちのリクエストが無くなった場合はlistenを解除する。
     if (pendingCallbacks.size === 0) {
-      suspend?.();
-      suspend = undefined;
+      unlisten?.();
+      unlisten = undefined;
     }
   };
 
-  return (...args) => {
-    if (suspend === undefined) {
-      suspend = port.listen<Response<Awaited<TReturned>>>(handleAllResponses);
+  // Clientの使用側からServerにリクエストを送信するための関数を定義する。
+  return (args, abortSignal) => {
+    // listenが解除済みの場合は再開する。
+    if (unlisten === undefined) {
+      unlisten = port.listen<Response<Awaited<TReturned>> | ErrorResponse>(handleAllResponses);
     }
 
-    const request = { id: generateId() as Request<TArgs>['id'], args } satisfies Request<TArgs>;
-    const promise = new Promise<Awaited<TReturned>>((resolve, reject) => {
-      pendingCallbacks.set(request.id, [resolve, reject]);
-      port.send(request);
-    });
+    const requestId = generateId() as Request<TArgs>['id'];
 
-    return promise;
+    // AbortSignalが指定されている場合は、abortイベントが来た際にその処理をするように設定する。
+    // AbortSignalとリクエストIDの紐付けもする。
+    if (abortSignal !== undefined) {
+      abortSignal.addEventListener('abort', handleAllAbortEvents, { once: true });
+      requestIdAbortSignalMap.set(requestId, abortSignal);
+      abortSignalRequestIdMap.set(abortSignal, requestId);
+    }
+
+    // Clientの使用側には、Serverの呼び出しをPromiseであるように見せる。
+    return new Promise<Awaited<TReturned>>((resolve, reject) => {
+      // Responseをresolve/rejectする処理は`handleAllResponses`に書いてある。
+      // `handleAllResponses`できるようにresolve/rejectとリクエストIDを紐付ける。
+      pendingCallbacks.set(requestId, [resolve, reject]);
+      // Serverにリクエストを送信する。
+      port.send<Request<TArgs>>({ type: 'request', id: requestId, args });
+    });
   };
 };
 
@@ -146,10 +249,48 @@ export const startServerFromPort = <
   func: TFunc,
   port: AsyncifyEventsPort,
 ): (() => void) =>
-  port.listen<Request<TArgs>>(async (request) => {
-    const returned = await func(...request.args);
-    port.send<Response<TReturned>>({ id: request.id, returned });
-  });
+  startAbortableServerFromPort<AbortableFunction<TArgs, TReturned>, TArgs, TReturned>(
+    (args: TArgs) => func(...args),
+    port,
+  );
+
+export const startAbortableServerFromPort = <
+  TFunc extends AbortableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = ReturnType<TFunc>,
+>(
+  func: TFunc,
+  port: AsyncifyEventsPort,
+): (() => void) => {
+  const abortControllers = new Map<Request<TArgs>['id'], AbortController>();
+
+  const handleRequest = async (request: Request<TArgs>) => {
+    const abortController = new AbortController();
+    abortControllers.set(request.id, abortController);
+    try {
+      const returned = await func(request.args, abortController.signal);
+      port.send<Response<TReturned>>({ type: 'response', id: request.id, returned });
+    } catch (error: unknown) {
+      port.send<ErrorResponse>({ type: 'errorResponse', id: request.id, returned: error });
+    } finally {
+      abortControllers.delete(request.id);
+    }
+  };
+
+  const handleAbortRequest = (request: AbortRequest) => {
+    const abortController = abortControllers.get(request.id);
+    if (abortController === undefined) {
+      return;
+    }
+    abortController.abort(request.reason);
+    abortControllers.delete(request.id);
+  };
+
+  const handlers = { request: handleRequest, abortRequest: handleAbortRequest };
+  const requestRouter = defineRouter(handlers, 'type');
+
+  return port.listen<Request<TArgs> | AbortRequest>(requestRouter);
+};
 
 export const portFromEventTarget = (me: EventTarget, other: EventTarget): AsyncifyEventsPort => ({
   send: <TRequest>(request: TRequest) => {

--- a/src/custom-event-utils.ts
+++ b/src/custom-event-utils.ts
@@ -1,0 +1,30 @@
+/** @internal */
+type DefaultEventHandlers<T extends { type: string }> = {
+  readonly [K in T['type']]: (this: unknown, event: CustomEvent<Extract<T, { type: K }>>) => void;
+};
+
+export const dispatchFunctionFromEventTarget =
+  <T extends { type: string }>(
+    eventTarget: EventTarget,
+  ): (<K extends T['type']>(eventName: K, detail: Extract<T, { type: K }>) => void) =>
+  (eventName, detail) => {
+    eventTarget.dispatchEvent(new CustomEvent<T>(eventName, { detail: detail }));
+  };
+
+export const subscribeHandlersToEventTarget = <
+  T extends { type: string },
+  THandlers extends DefaultEventHandlers<T> = DefaultEventHandlers<T>,
+>(
+  handlers: THandlers,
+  eventTarget: EventTarget,
+): (() => void) => {
+  for (const key of Object.keys(handlers)) {
+    eventTarget.addEventListener(key, handlers[key as keyof THandlers] as EventListener);
+  }
+
+  return () => {
+    for (const key of Object.keys(handlers)) {
+      eventTarget.removeEventListener(key, handlers[key as keyof THandlers] as EventListener);
+    }
+  };
+};

--- a/src/execution-queue.test.ts
+++ b/src/execution-queue.test.ts
@@ -1,12 +1,12 @@
 import { beforeAll, describe, expect, jest, test } from '@jest/globals';
-import { Client, EventTargetTerminal, Server } from './asyncify-events.js';
 import {
+  type Cancel,
+  type Enqueue,
   type Execution,
-  type ExecutionEvent,
   type ExecutionId,
   type ExecutionRepository,
-  createExecutionQueueGateway,
-  createExecutionQueueTimeWindowRateLimitationStrategy,
+  createCalculateExecutionDateFromTimeWindowRateLimitationRules,
+  executionQueue,
 } from './execution-queue.js';
 import {
   type Filters,
@@ -14,19 +14,17 @@ import {
   type OrderBy,
   repositorySymbol,
 } from './repository-utils.js';
-import type { TypedEventTarget } from './typed-event-target.js';
+import { type SchedulableFunction, schedulableFunctionFromFunction } from './timer.js';
 
 class ExecutionRepositoryMock<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends never[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends never[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
 > implements ExecutionRepository<TFunc, TArgs, TReturned>
 {
-  public readonly underlyingMap = new Map<ExecutionId, Execution<TFunc, TArgs, TReturned>>();
+  public readonly underlyingMap = new Map<ExecutionId, Execution<TArgs>>();
 
-  public async getOneById(
-    id: ExecutionId,
-  ): Promise<FromRepository<Execution<TFunc, TArgs, TReturned>> | undefined> {
+  public async getOneById(id: ExecutionId): Promise<FromRepository<Execution<TArgs>> | undefined> {
     const latestVersion = this.underlyingMap.get(id);
     if (latestVersion === undefined) {
       return undefined;
@@ -35,15 +33,11 @@ class ExecutionRepositoryMock<
   }
 
   public async getMany(params: {
-    readonly filters?: Filters<
-      Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'>
-    >;
-    readonly orderBy: OrderBy<
-      Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'>
-    >;
+    readonly filters?: Filters<Pick<Execution<TArgs>, 'executedAt' | 'status'>>;
+    readonly orderBy: OrderBy<Pick<Execution<TArgs>, 'executedAt' | 'status'>>;
     readonly offset?: number | undefined;
     readonly limit?: number | undefined;
-  }): Promise<readonly FromRepository<Execution<TFunc, TArgs, TReturned>>[] | readonly []> {
+  }): Promise<readonly FromRepository<Execution<TArgs>>[] | readonly []> {
     return (await this.getExecutionsBase(params))
       .sort(
         (a, b) =>
@@ -58,18 +52,14 @@ class ExecutionRepositoryMock<
   }
 
   public async count(params: {
-    readonly filters?: Filters<
-      Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'>
-    >;
+    readonly filters?: Filters<Pick<Execution<TArgs>, 'executedAt' | 'status'>>;
   }): Promise<number> {
     return (await this.getExecutionsBase(params)).length;
   }
 
   private async getExecutionsBase(params: {
-    readonly filters?: Filters<
-      Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'>
-    >;
-  }): Promise<Execution<TFunc, TArgs, TReturned>[]> {
+    readonly filters?: Filters<Pick<Execution<TArgs>, 'executedAt' | 'status'>>;
+  }): Promise<Execution<TArgs>[]> {
     return [...this.underlyingMap.entries()]
       .filter(([_, execution]) => {
         const conditions = [
@@ -77,15 +67,15 @@ class ExecutionRepositoryMock<
             execution.executedAt.getTime() === params.filters.executedAt.getTime(),
 
           params.filters?.executedAt instanceof Date === true ||
-            params.filters?.executedAt?.from === undefined ||
-            params.filters.executedAt.from <= execution.executedAt,
+            params.filters?.executedAt?.[0] !== 'lte' ||
+            params.filters.executedAt[1] <= execution.executedAt,
 
           params.filters?.executedAt instanceof Date === true ||
-            params.filters?.executedAt?.until === undefined ||
-            execution.executedAt <= params.filters.executedAt.until,
+            params.filters?.executedAt?.[0] !== 'gte' ||
+            execution.executedAt <= params.filters.executedAt[1],
 
-          params.filters?.isExecuted === undefined ||
-            execution.isExecuted === params.filters.isExecuted,
+          // 文字列の他のクエリは使わないので未サポート
+          typeof params.filters?.status !== 'string' || execution.status === params.filters?.status,
         ];
 
         return !conditions.some((condition) => condition === false);
@@ -93,11 +83,11 @@ class ExecutionRepositoryMock<
       .map(([_, execution]) => execution);
   }
 
-  public async createOne(execution: Execution<TFunc, TArgs, TReturned>): Promise<void> {
+  public async createOne(execution: Execution<TArgs>): Promise<void> {
     this.underlyingMap.set(execution.id, execution);
   }
 
-  public async updateOne(execution: Execution<TFunc, TArgs, TReturned>): Promise<void> {
+  public async updateOne(execution: Execution<TArgs>): Promise<void> {
     this.underlyingMap.set(execution.id, execution);
   }
 
@@ -108,45 +98,39 @@ class ExecutionRepositoryMock<
 
 const expectedExecutionDateMap = new Map<number, Date>();
 const actualExecutionDateMap = new Map<number, Date>();
-const me = new EventTarget();
-const destination = new EventTarget();
-const server = new Server<(id: number) => Date>({
-  terminal: new EventTargetTerminal({ me: destination, destination: me }),
-  func: (id: number) => {
-    const actualExecutedDate = new Date();
-    actualExecutionDateMap.set(id, actualExecutedDate);
-    return actualExecutedDate;
-  },
-});
-const client = new Client<typeof server>({
-  terminal: new EventTargetTerminal({ me, destination }),
-});
-const executionRepository = new ExecutionRepositoryMock<(id: number) => void>();
+const func = (id: number) => {
+  const actualExecutedDate = new Date();
+  actualExecutionDateMap.set(id, actualExecutedDate);
+  return actualExecutedDate;
+};
+const schedulableFunction = schedulableFunctionFromFunction(func);
+const executionRepository = new ExecutionRepositoryMock<SchedulableFunction<[number], Date>>();
+const executionQueueEventTarget = new EventTarget();
+
 const timeWindowRateLimitationRules = [
   { timeWindowMs: 5000, executionCountPerTimeWindow: 10 },
   { timeWindowMs: 10000, executionCountPerTimeWindow: 15 },
   { timeWindowMs: 20000, executionCountPerTimeWindow: 20 },
 ];
 
-const executionEventTarget: TypedEventTarget<ExecutionEvent<(id: number) => Date>> =
-  new EventTarget();
-
-const executionQueueGateway = createExecutionQueueGateway({
-  client,
-  executionEventTarget,
-  executionRepository,
-  strategy: createExecutionQueueTimeWindowRateLimitationStrategy({ timeWindowRateLimitationRules }),
-});
-
-jest.useFakeTimers();
-jest.spyOn(global, 'setTimeout');
-jest.spyOn(global, 'setInterval');
+let executionQueueGateway: { readonly enqueue: Enqueue<[number]>; readonly cancel: Cancel };
 
 beforeAll(async () => {
-  executionQueueGateway.start({});
+  jest.useFakeTimers();
+  jest.spyOn(global, 'setTimeout');
+  jest.spyOn(global, 'setInterval');
+
+  executionQueueGateway = await executionQueue({
+    schedulableFunction,
+    executionQueueEventTarget,
+    executionRepository,
+    calculateExecutionDate: createCalculateExecutionDateFromTimeWindowRateLimitationRules(
+      timeWindowRateLimitationRules,
+    ),
+  });
 
   for (let i = 0; i < 100; i += 1) {
-    const { executedAt } = await executionQueueGateway.enqueue({ args: [i] });
+    const { executedAt } = await executionQueueGateway.enqueue(i);
     expectedExecutionDateMap.set(i, executedAt);
   }
 });
@@ -183,7 +167,7 @@ describe('ExecutionQueueWithTimeWindowRateLimitation', () => {
           Math.abs(actualExecutedDate?.getTime() - expectedExecutionDate.getTime()),
         ).toBeLessThanOrEqual(1);
       });
-      expect(await executionRepository.count({ filters: { isExecuted: true } })).toEqual(100);
+      expect(await executionRepository.count({ filters: { status: 'completed' } })).toEqual(100);
     });
   });
 });

--- a/src/execution-queue.ts
+++ b/src/execution-queue.ts
@@ -1,585 +1,312 @@
-import type { Client, Server } from './asyncify-events.js';
+import {
+  dispatchFunctionFromEventTarget,
+  subscribeHandlersToEventTarget,
+} from './custom-event-utils.js';
 import type { NominalPrimitive } from './nominal-primitive.type.js';
-import { bulkPreApply } from './pre-apply.js';
 import { type Id, generateId } from './random-values.js';
 import type { Filters, FromRepository, OrderBy } from './repository-utils.js';
-import { type State, createState } from './state.js';
+import { createState } from './state.js';
 import {
   type TimeWindowRateLimitationRule,
   calculateNextExecutionDate,
 } from './time-window-rate-limitation.js';
-import { executeAt } from './timer.js';
-import type { TypedEventTarget } from './typed-event-target.js';
-import type { PartiallyPartial } from './utils.type.js';
+import type { SchedulableFunction } from './timer.js';
 
-const executionTypeSymbol = Symbol('execution.type');
-
-/**
- * Represents a unique identifier for an {@link Execution} entry in the queue.
- */
+//#region interfaces
+const executionTypeSymbol = Symbol('executionType');
 export type ExecutionId = NominalPrimitive<Id, typeof executionTypeSymbol>;
-
-/**
- * Represents a single execution entry in the queue.
- * Contains execution id, arguments, scheduled execution date, and execution status.
- */
-export type Execution<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> = {
-  readonly [executionTypeSymbol]: typeof executionTypeSymbol;
+export type Execution<TArgs extends unknown[]> = {
   readonly id: ExecutionId;
-  readonly args: Readonly<TArgs>;
+  readonly args: TArgs;
   readonly executedAt: Date;
-  readonly isExecuted: boolean;
+  readonly status: 'pending' | 'canceled' | 'running' | 'completed' | 'failed';
 };
 
-/**
- * Utility functions for creating and updating {@link Execution} objects.
- */
-export const ExecutionReducers = {
-  create: <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: Pick<Execution<TFunc, TArgs, TReturned>, 'args' | 'executedAt'>,
-  ): Execution<TFunc, TArgs, TReturned> => {
-    return {
-      [executionTypeSymbol]: executionTypeSymbol,
-      id: generateId() as ExecutionId,
-      args: params.args,
-      executedAt: params.executedAt,
-      isExecuted: false,
-    };
-  },
+export type Enqueue<TArgs extends unknown[]> = (
+  ...args: TArgs
+) => Promise<{ readonly executionId: ExecutionId; readonly executedAt: Date }>;
+export type Cancel = (executionId: ExecutionId, reason?: unknown) => Promise<void>;
 
-  toExecuted: <
-    S extends Execution<TFunc, TArgs, TReturned>,
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    self: S,
-  ): S => ({ ...self, isExecuted: true }),
+export type CalculateExecutionDate = (
+  this: unknown,
+  repository: Pick<
+    ExecutionRepository<SchedulableFunction<unknown[], unknown>>,
+    'getOneById' | 'getMany' | 'count'
+  >,
+) => Promise<Date>;
 
-  toExecutionDateUpdated: <
-    S extends Execution<TFunc, TArgs, TReturned>,
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    self: S,
-    params: { readonly newExecutedAt: Date },
-  ): S => ({ ...self, executedAt: params.newExecutedAt }),
-
-  fromParams: <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: Omit<Execution<TFunc, TArgs, TReturned>, typeof executionTypeSymbol>,
-  ) => ({ [executionTypeSymbol]: executionTypeSymbol, ...params }) as const,
-};
-
-/**
- * Represents events that occur in the execution queue, such as schedule changes or completion.
- */
-export type ExecutionEvent<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
+export type ExecutionQueueEventData<
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
 > =
-  | ExecutionScheduleChangeEvent<TFunc, TArgs, TReturned>
-  | ExecutionCompleteEvent<TFunc, TArgs, TReturned>;
+  | ExecutionQueueScheduleUpdatedEventData<TFunc, TArgs, TReturned>
+  | ExecutionQueueStartedEventData<TFunc, TArgs, TReturned>
+  | ExecutionQueueCompletedEventData<TFunc, TArgs, TReturned>
+  | ExecutionQueueFailedEventData<TFunc, TArgs, TReturned>
+  | ExecutionQueueErrorEventData;
+export type ExecutionQueueScheduleUpdatedEventData<
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
+> = {
+  readonly type: 'scheduleUpdated';
+  readonly executionId: ExecutionId;
+  readonly args: TArgs;
+  readonly previousExecutedAt: Date;
+  readonly newExecutedAt: Date;
+};
+export type ExecutionQueueStartedEventData<
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
+> = {
+  readonly type: 'started';
+  readonly executionId: ExecutionId;
+  readonly args: TArgs;
+};
+export type ExecutionQueueCompletedEventData<
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
+> = {
+  readonly type: 'completed';
+  readonly executionId: ExecutionId;
+  readonly args: TArgs;
+  readonly value: TReturned;
+};
+export type ExecutionQueueFailedEventData<
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
+> = {
+  readonly type: 'failed';
+  readonly executionId: ExecutionId;
+  readonly args: TArgs;
+  readonly value: unknown;
+};
+export type ExecutionQueueErrorEventData = { readonly type: 'error'; readonly error: unknown };
 
-/**
- * Event fired when the execution schedule is changed.
- */
-export class ExecutionScheduleChangeEvent<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> extends Event {
-  public readonly type: 'scheduleChange';
-  public readonly id: ExecutionId;
-  public readonly args: Readonly<TArgs>;
-  public readonly newSchedule: Date;
+export type ExecutionRepository<
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
+> = {
+  getOneById(this: unknown, id: ExecutionId): Promise<FromRepository<Execution<TArgs>> | undefined>;
+  getMany(
+    this: unknown,
+    params: {
+      readonly filters?: Filters<Pick<Execution<TArgs>, 'executedAt' | 'status'>>;
+      readonly orderBy: OrderBy<Pick<Execution<TArgs>, 'executedAt' | 'status'>>;
+      readonly offset?: number | undefined;
+      readonly limit?: number | undefined;
+    },
+  ): Promise<readonly FromRepository<Execution<TArgs>>[] | readonly []>;
+  count(
+    this: unknown,
+    params: { readonly filters?: Filters<Pick<Execution<TArgs>, 'executedAt' | 'status'>> },
+  ): Promise<number>;
+  createOne(this: unknown, execution: Execution<TArgs>): Promise<void>;
+  updateOne(this: unknown, execution: FromRepository<Execution<TArgs>>): Promise<void>;
+  deleteOneById(this: unknown, executionId: ExecutionId): Promise<void>;
+};
+//#endregion
 
-  public constructor(
-    params: Pick<
-      ExecutionScheduleChangeEvent<TFunc, TArgs, TReturned>,
-      'id' | 'args' | 'newSchedule'
-    >,
-  ) {
-    super('scheduleChange');
-    this.type = 'scheduleChange';
-    this.id = params.id;
-    this.args = params.args;
-    this.newSchedule = params.newSchedule;
-  }
-}
-
-/**
- * Event fired when an execution is completed.
- */
-export class ExecutionCompleteEvent<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> extends Event {
-  public readonly type: 'complete';
-  public readonly id: ExecutionId;
-  public readonly args: Readonly<TArgs>;
-  public readonly returned: TReturned;
-
-  public constructor(
-    params: Pick<ExecutionCompleteEvent<TFunc, TArgs, TReturned>, 'id' | 'args' | 'returned'>,
-  ) {
-    super('complete');
-    this.type = 'complete';
-    this.id = params.id;
-    this.args = params.args;
-    this.returned = params.returned;
-  }
-}
-
-/**
- * Represents the state of the execution queue (idle or reserved).
- */
-export type ExecutionQueueState =
+type StateValue<TArgs extends unknown[]> =
   | {
-      readonly status: 'reserved';
-      readonly id: ExecutionId;
+      readonly status: 'running';
+      readonly execution: FromRepository<Execution<TArgs>>;
       readonly abortController: AbortController;
     }
   | { readonly status: 'idle' };
 
-/**
- * Public interface for the execution queue gateway.
- * Provides methods to enqueue, cancel, and start the queue.
- */
-export type ExecutionQueueGateway<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> = {
-  enqueue(
-    this: unknown,
-    params: { readonly args: Readonly<TArgs> },
-  ): Promise<Execution<TFunc, TArgs, TReturned>>;
-
-  cancel(this: unknown, params: { readonly id: ExecutionId }): Promise<void>;
-
-  start(params: Record<never, never> & {}): void;
+type ControlEventData<TArgs extends unknown[]> =
+  | ControlPopEventData
+  | ControlRunEventData<TArgs>
+  | ControlSuspendEventData;
+type ControlPopEventData = { readonly type: 'pop' };
+type ControlRunEventData<TArgs extends unknown[]> = {
+  readonly type: 'run';
+  readonly execution: FromRepository<Execution<TArgs>>;
+  readonly abortController: AbortController;
 };
+type ControlSuspendEventData = { readonly type: 'suspend' };
 
-/**
- * Repository interface for persisting and retrieving execution entries.
- */
-export type ExecutionRepository<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> = {
-  getOneById(
-    this: ExecutionRepository<TFunc, TArgs, TReturned>,
-    id: ExecutionId,
-  ): Promise<FromRepository<Execution<TFunc, TArgs, TReturned>> | undefined>;
-
-  getMany(
-    this: ExecutionRepository<TFunc, TArgs, TReturned>,
-    params: {
-      readonly filters?: Filters<
-        Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'> // `id`の型が不定なので取り除いている。以下同様。
-      >;
-      readonly orderBy: OrderBy<
-        Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'>
-      >;
-      readonly offset?: number | undefined;
-      readonly limit?: number | undefined;
-    },
-  ): Promise<readonly FromRepository<Execution<TFunc, TArgs, TReturned>>[] | readonly []>;
-
-  count(
-    this: ExecutionRepository<TFunc, TArgs, TReturned>,
-    params: {
-      readonly filters?: Filters<
-        Pick<Execution<TFunc, TArgs, TReturned>, 'executedAt' | 'isExecuted'>
-      >;
-    },
-  ): Promise<number>;
-
-  createOne(
-    this: ExecutionRepository<TFunc, TArgs, TReturned>,
-    execution: Execution<TFunc, TArgs, TReturned>,
-  ): Promise<void>;
-
-  updateOne(
-    this: ExecutionRepository<TFunc, TArgs, TReturned>,
-    execution: FromRepository<Execution<TFunc, TArgs, TReturned>>,
-  ): Promise<void>;
-
-  deleteOneById(this: ExecutionRepository<TFunc, TArgs, TReturned>, id: ExecutionId): Promise<void>;
-};
-
-//#region ExecutionQueueGateway
-/**
- * Dependencies required for the execution queue gateway implementation.
- */
-export type ExecutionQueueGatewayDependencies<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> = {
-  readonly strategy: ExecutionQueueStrategy<TFunc, TArgs, TReturned>;
-  readonly executionQueueState: State<ExecutionQueueState>;
+export const executionQueue = async <
+  TFunc extends SchedulableFunction<TArgs, TReturned>,
+  TArgs extends unknown[] = Parameters<TFunc>[0],
+  TReturned = Awaited<ReturnType<TFunc>>,
+>(params: {
+  readonly schedulableFunction: TFunc;
+  readonly calculateExecutionDate: CalculateExecutionDate;
+  readonly executionQueueEventTarget: EventTarget;
   readonly executionRepository: ExecutionRepository<TFunc, TArgs, TReturned>;
-  readonly client: Client<Server<TFunc, TArgs, TReturned>, TArgs, TReturned, TFunc>;
-  readonly executionEventTarget: TypedEventTarget<ExecutionEvent<TFunc, TArgs, TReturned>>;
-  readonly reservationEventTarget: EventTarget;
-};
+}): Promise<{ readonly enqueue: Enqueue<TArgs>; readonly cancel: Cancel }> => {
+  const queueState = createState<StateValue<TArgs>>({ status: 'idle' });
+  const controlEventTarget = new EventTarget();
+  let unsubscribeControlEventHandlers: (() => void) | undefined;
 
-/**
- * Main implementation of the {@linkcode ExecutionQueueGateway}.
- * Delegates operations to the provided strategy and dependencies.
- */
-export const ExecutionQueueGatewayImplementation = {
-  start: <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: ExecutionQueueGatewayDependencies<TFunc, TArgs, TReturned>,
-  ): { readonly stop: () => void } => {
-    params.strategy.handleStart(params);
+  const dispatchExecutionQueueEvent = dispatchFunctionFromEventTarget<
+    ExecutionQueueEventData<TFunc, TArgs, TReturned>
+  >(params.executionQueueEventTarget);
+  const dispatchControlEvent =
+    dispatchFunctionFromEventTarget<ControlEventData<TArgs>>(controlEventTarget);
 
-    const handleEnqueue = () => params.strategy.handleEnqueue(params);
-    const handleComplete = () => params.strategy.handleComplete(params);
-    const handleCancel = () => params.strategy.handleCancel(params);
-    params.reservationEventTarget.addEventListener('enqueue', handleEnqueue);
-    params.reservationEventTarget.addEventListener('complete', handleComplete);
-    params.reservationEventTarget.addEventListener('cancel', handleCancel);
+  const handleRun = async (event: CustomEvent<ControlRunEventData<TArgs>>) => {
+    const { execution, abortController } = event.detail;
 
-    return {
-      stop: () => {
-        params.reservationEventTarget.removeEventListener('enqueue', handleEnqueue);
-        params.reservationEventTarget.removeEventListener('complete', handleComplete);
-        params.reservationEventTarget.removeEventListener('cancel', handleCancel);
-      },
-    };
-  },
+    try {
+      // 取り出した実行待ちの状態をrepository内でrunningに更新する。
+      await params.executionRepository.updateOne({ ...execution, status: 'running' });
 
-  enqueue: async <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: { readonly args: Readonly<TArgs> } & Pick<
-      ExecutionQueueGatewayDependencies<TFunc, TArgs, TReturned>,
-      'strategy' | 'executionRepository' | 'reservationEventTarget'
-    >,
-  ): Promise<Execution<TFunc, TArgs, TReturned>> => {
-    const executedAt = await params.strategy.calculateExecutionDate({
-      executionRepository: params.executionRepository,
-    });
-    const execution = ExecutionReducers.create({ args: params.args, executedAt });
-    await params.executionRepository.createOne(execution);
+      try {
+        // 実行開始イベントを発火する。
+        dispatchExecutionQueueEvent('started', {
+          type: 'started',
+          executionId: execution.id,
+          args: execution.args,
+        });
 
-    params.reservationEventTarget.dispatchEvent(new Event('enqueue'));
+        // 取り出した実行待ちを実行する。
+        const executionDate = new Date(Math.max(execution.executedAt.getTime(), Date.now()));
+        const returned = await params.schedulableFunction(
+          execution.args,
+          executionDate,
+          abortController.signal,
+        );
 
-    return execution;
-  },
+        // 実行に成功した場合は、完了イベントを発火する。
+        dispatchExecutionQueueEvent('completed', {
+          type: 'completed',
+          executionId: execution.id,
+          args: execution.args,
+          value: returned,
+        });
+      } catch (error: unknown) {
+        // 実行に失敗した場合は、失敗イベントを発火する。
+        dispatchExecutionQueueEvent('failed', {
+          type: 'failed',
+          executionId: execution.id,
+          args: execution.args,
+          value: error,
+        });
 
-  cancel: async <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: { readonly id: ExecutionId } & Pick<
-      ExecutionQueueGatewayDependencies<TFunc, TArgs, TReturned>,
-      'executionQueueState' | 'executionRepository' | 'reservationEventTarget'
-    >,
-  ): Promise<void> => {
-    const currentState = params.executionQueueState.get();
-    if (currentState.status === 'reserved' && params.id === currentState.id) {
-      currentState.abortController.abort();
-      params.executionQueueState.set({ status: 'idle' });
+        // repositoryを更新する。
+        await params.executionRepository.updateOne({ ...execution, status: 'failed' });
+
+        return;
+      }
+
+      // repositoryを更新する。
+      await params.executionRepository.updateOne({ ...execution, status: 'completed' });
+    } catch (error: unknown) {
+      // repositoryの更新でエラーが発生した場合は、エラーイベントを発火する。
+      dispatchExecutionQueueEvent('error', { type: 'error', error });
+    } finally {
+      queueState.set({ status: 'idle' });
+      dispatchControlEvent('pop', { type: 'pop' });
     }
+  };
+  const handlePop = async () => {
+    try {
+      // 次の実行待ちを取り出す。
+      const [nextExecution] = await params.executionRepository.getMany({
+        filters: { status: 'pending' },
+        orderBy: { executedAt: 'asc' },
+        limit: 1,
+      });
 
-    const execution = await params.executionRepository.getOneById(params.id);
-    if (execution?.isExecuted === true) {
-      return;
+      // 実行待ちがない場合は、何もしない。
+      if (nextExecution === undefined) {
+        dispatchControlEvent('suspend', { type: 'suspend' });
+        return;
+      }
+
+      const abortController = new AbortController();
+      queueState.set({ status: 'running', execution: nextExecution, abortController });
+      dispatchControlEvent('run', { type: 'run', execution: nextExecution, abortController });
+    } catch (error: unknown) {
+      // repositoryなどでエラーが発生した場合は、エラーイベントを発火する。
+      dispatchExecutionQueueEvent('error', { type: 'error', error });
     }
+  };
+  const handleSuspend = async () => {
+    unsubscribeControlEventHandlers?.();
+  };
+  const subscribeIfNeeded = () => {
+    if (unsubscribeControlEventHandlers === undefined) {
+      unsubscribeControlEventHandlers = subscribeHandlersToEventTarget<ControlEventData<TArgs>>(
+        { run: handleRun, pop: handlePop, suspend: handleSuspend },
+        controlEventTarget,
+      );
+    }
+  };
 
-    await params.executionRepository.deleteOneById(params.id);
-
-    params.reservationEventTarget.dispatchEvent(new Event('cancel'));
-  },
-} as const;
-
-/**
- * Create a pre-applied execution queue gateway with dependencies.
- *
- * ## Usage
- * ```ts
- * import { type ExecutionQueueState } from '@mgn901/mgn901-utils-ts/execution-queue';
- * import { createState } from '@mgn901/mgn901-utils-ts/state';
- *
- * // Declarations of `client` and `executionRepository` is omitted for brevity
- *
- * // Create a pre-applied ExecutionQueueGateway
- * const executionQueueGateway = createExecutionQueueGateway({
- *   client: client,
- *   executionQueueState: createState<ExecutionQueueState>({ status: 'idle' }),
- *   executionEventTarget: new EventTarget(),
- *   reservationEventTarget: new EventTarget(),
- *   executionRepository: executionRepository,
- *   strategy: createExecutionQueueTimeWindowRateLimitationStrategy({
- *     timeWindowRateLimitationRules: [
- *       { timeWindowMs: 5000, executionCountPerTimeWindow: 10 },
- *       { timeWindowMs: 10000, executionCountPerTimeWindow: 15 },
- *       { timeWindowMs: 20000, executionCountPerTimeWindow: 20 },
- *     ],
- *   }),
- * });
- *
- * // Start the ExecutionQueueGateway
- * executionQueueGateway.start({});
- *
- * // Enqueue a function calling
- * executionQueueGateway.enqueue({ args: [0] });
- * ```
- */
-export const createExecutionQueueGateway = <
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
->(
-  preAppliedParams: PartiallyPartial<
-    ExecutionQueueGatewayDependencies<TFunc, TArgs, TReturned>,
-    'client' | 'executionEventTarget' | 'executionRepository' | 'strategy'
-  >,
-) =>
-  bulkPreApply<
-    ExecutionQueueGateway<TFunc, TArgs, TReturned>,
-    ExecutionQueueGatewayDependencies<TFunc, TArgs, TReturned>
-  >(ExecutionQueueGatewayImplementation, {
-    reservationEventTarget: new EventTarget(),
-    executionQueueState: createState<ExecutionQueueState>({ status: 'idle' }),
-    ...preAppliedParams,
+  //#region 初期化
+  const waitingExecutionsBeforeStart = await params.executionRepository.getMany({
+    filters: { status: 'pending' },
+    orderBy: { executedAt: 'asc' },
   });
-//#endregion
+  if (waitingExecutionsBeforeStart.length > 0) {
+    for (const execution of waitingExecutionsBeforeStart) {
+      const newExecutedAt = await params.calculateExecutionDate(params.executionRepository);
+      await params.executionRepository.updateOne({ ...execution, executedAt: newExecutedAt });
+      dispatchExecutionQueueEvent('scheduleUpdated', {
+        type: 'scheduleUpdated',
+        executionId: execution.id,
+        args: execution.args,
+        previousExecutedAt: execution.executedAt,
+        newExecutedAt,
+      });
+    }
+    subscribeIfNeeded();
+    dispatchControlEvent('pop', { type: 'pop' });
+  }
+  //#endregion
 
-/**
- * Parameters passed to strategy handlers for execution queue operations.
- */
-export type ExecutionQueueStrategyHandlerParams<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> = {
-  readonly executionQueueState: State<ExecutionQueueState>;
-  readonly executionRepository: ExecutionRepository<TFunc, TArgs, TReturned>;
-  readonly client: Client<Server<TFunc, TArgs, TReturned>, TArgs, TReturned, TFunc>;
-  readonly executionEventTarget: TypedEventTarget<ExecutionEvent<TFunc, TArgs, TReturned>>;
-  readonly reservationEventTarget: EventTarget;
+  return {
+    enqueue: async (...args) => {
+      const execution = {
+        id: generateId() as ExecutionId,
+        args,
+        executedAt: await params.calculateExecutionDate(params.executionRepository),
+        status: 'pending',
+      } satisfies Execution<TArgs>;
+      await params.executionRepository.createOne(execution);
+      subscribeIfNeeded();
+      dispatchControlEvent('pop', { type: 'pop' });
+      return { executionId: execution.id, executedAt: execution.executedAt };
+    },
+
+    cancel: async (executionId, reason) => {
+      const queueStateValue = queueState.get();
+      if (queueStateValue.status === 'running' && queueStateValue?.execution.id === executionId) {
+        queueStateValue.abortController.abort(reason);
+      } else {
+        await params.executionRepository.deleteOneById(executionId);
+        subscribeIfNeeded();
+        dispatchControlEvent('pop', { type: 'pop' });
+      }
+    },
+  };
 };
 
-/**
- * Interface for pluggable execution queue strategies (e.g., scheduling, rate limiting).
- */
-export type ExecutionQueueStrategy<
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
-> = {
-  calculateExecutionDate(params: {
-    readonly executionRepository: ExecutionRepository<TFunc, TArgs, TReturned>;
-  }): Promise<Date>;
-
-  handleEnqueue(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>,
-  ): Promise<void>;
-
-  handleComplete(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>,
-  ): Promise<void>;
-
-  handleCancel(params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>): Promise<void>;
-
-  handleStart(params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>): Promise<void>;
-};
-
-/**
- * Dependencies for the {@linkcode ExecutionQueueTimeWindowRateLimitationStrategy}.
- */
-export type ExecutionQueueTimeWindowRateLimitationStrategyDependencies = {
-  readonly timeWindowRateLimitationRules: readonly TimeWindowRateLimitationRule[];
-};
-
-/**
- * Strategy implementation of {@linkcode ExecutionQueueStrategy} for time window rate limiting of executions.
- */
-export const ExecutionQueueTimeWindowRateLimitationStrategy = {
-  calculateExecutionDate<
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: {
-      readonly executionRepository: ExecutionRepository<TFunc, TArgs, TReturned>;
-    } & ExecutionQueueTimeWindowRateLimitationStrategyDependencies,
-  ): Promise<Date> {
-    return calculateNextExecutionDate({
-      timeWindowRateLimitationRules: params.timeWindowRateLimitationRules,
+export const createCalculateExecutionDateFromTimeWindowRateLimitationRules =
+  (rules: readonly TimeWindowRateLimitationRule[]): CalculateExecutionDate =>
+  async (repository) =>
+    calculateNextExecutionDate({
+      timeWindowRateLimitationRules: rules,
       getNewestExecutionDateInLatestTimeWindow: async () =>
-        (await params.executionRepository.getMany({ orderBy: { executedAt: 'desc' }, limit: 1 }))[0]
-          ?.executedAt ?? new Date(),
+        (await repository.getMany({ orderBy: { executedAt: 'desc' }, limit: 1 }))[0]?.executedAt ??
+        new Date(),
       getOldestExecutionDateInLatestTimeWindow: async (startOfLastTimeWindow: Date) =>
         (
-          await params.executionRepository.getMany({
-            filters: { executedAt: { from: startOfLastTimeWindow } },
+          await repository.getMany({
+            filters: { executedAt: ['lte', startOfLastTimeWindow] },
             orderBy: { executedAt: 'asc' },
             limit: 1,
           })
         )[0]?.executedAt,
       countExecutionsInLatestTimeWindow: (startOfLastTimeWindow: Date) =>
-        params.executionRepository.count({
-          filters: { executedAt: { from: startOfLastTimeWindow } },
-        }),
+        repository.count({ filters: { executedAt: ['lte', startOfLastTimeWindow] } }),
     });
-  },
-
-  handleEnqueue: <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>,
-  ): Promise<void> => {
-    return ExecutionQueueTimeWindowRateLimitationStrategy.handleNext(params);
-  },
-
-  handleComplete: <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>,
-  ): Promise<void> => {
-    return ExecutionQueueTimeWindowRateLimitationStrategy.handleNext(params);
-  },
-
-  handleCancel: <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>,
-  ): Promise<void> => {
-    return ExecutionQueueTimeWindowRateLimitationStrategy.handleNext(params);
-  },
-
-  handleStart: async <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned> &
-      ExecutionQueueTimeWindowRateLimitationStrategyDependencies,
-  ): Promise<void> => {
-    const waitingExecutions = await params.executionRepository.getMany({
-      filters: { isExecuted: false },
-      orderBy: { executedAt: 'asc' },
-    });
-    for (const execution of waitingExecutions) {
-      const newExecutedAt =
-        await ExecutionQueueTimeWindowRateLimitationStrategy.calculateExecutionDate({
-          executionRepository: params.executionRepository,
-          timeWindowRateLimitationRules: params.timeWindowRateLimitationRules,
-        });
-      const updatedExecution = ExecutionReducers.toExecutionDateUpdated<
-        FromRepository<Execution<TFunc, TArgs, TReturned>>,
-        TFunc,
-        TArgs,
-        TReturned
-      >(execution, { newExecutedAt });
-      params.executionRepository.updateOne(updatedExecution);
-    }
-    return ExecutionQueueTimeWindowRateLimitationStrategy.handleNext(params);
-  },
-
-  handleNext: async <
-    TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-    TArgs extends unknown[] = Parameters<TFunc>,
-    TReturned = ReturnType<TFunc>,
-  >(
-    params: ExecutionQueueStrategyHandlerParams<TFunc, TArgs, TReturned>,
-  ): Promise<void> => {
-    // すでに予約された実行がある場合は、何もしない。
-    if (params.executionQueueState.get().status !== 'idle') {
-      return;
-    }
-
-    // 次の実行待ちを取り出す。
-    const [nextExecution] = await params.executionRepository.getMany({
-      filters: { isExecuted: false },
-      orderBy: { executedAt: 'asc' },
-      limit: 1,
-    });
-    if (nextExecution === undefined) {
-      return;
-    }
-
-    // 次の実行待ちを予約する。
-    const abortController = new AbortController();
-    params.executionQueueState.set({
-      status: 'reserved',
-      id: nextExecution.id,
-      abortController: new AbortController(),
-    });
-    const executionDate = new Date(Math.max(nextExecution.executedAt.getTime(), Date.now()));
-
-    executeAt({
-      date: executionDate,
-      func: async () => {
-        const returned = await params.client.request(...nextExecution.args);
-        await params.executionRepository.updateOne(
-          ExecutionReducers.toExecuted<typeof nextExecution, TFunc, TArgs, TReturned>(
-            nextExecution,
-          ),
-        );
-
-        params.executionQueueState.set({ status: 'idle' });
-
-        params.executionEventTarget.dispatchEvent(
-          new ExecutionCompleteEvent<TFunc, TArgs, TReturned>({
-            id: nextExecution.id,
-            args: nextExecution.args,
-            returned,
-          }),
-        );
-
-        params.reservationEventTarget.dispatchEvent(new Event('complete'));
-      },
-      abortSignal: abortController.signal,
-    });
-  },
-} as const;
-
-/**
- * Create a pre-applied {@linkcode ExecutionQueueStrategy} for time window rate limiting.
- */
-export const createExecutionQueueTimeWindowRateLimitationStrategy = <
-  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
-  TArgs extends unknown[] = Parameters<TFunc>,
-  TReturned = ReturnType<TFunc>,
->(
-  preAppliedParams: ExecutionQueueTimeWindowRateLimitationStrategyDependencies,
-) =>
-  bulkPreApply<
-    ExecutionQueueStrategy<TFunc, TArgs, TReturned>,
-    ExecutionQueueTimeWindowRateLimitationStrategyDependencies
-  >(ExecutionQueueTimeWindowRateLimitationStrategy, preAppliedParams);

--- a/src/repository-utils.ts
+++ b/src/repository-utils.ts
@@ -2,27 +2,26 @@ import type { FieldsOf, OmitByValue, PickByValue } from './utils.type';
 
 const latestVersion = Symbol('repository.latestVersion');
 
-export const repositorySymbol = {
-  latestVersion: latestVersion,
-} as const;
+export const repositorySymbol = { latestVersion: latestVersion } as const;
 
+export type LogicalFilter<TFilter> = AndFilter<TFilter> | OrFilter<TFilter> | NotFilter<TFilter>;
+export type AndFilter<TFilter> = ['and', ...(TFilter | LogicalFilter<TFilter>)[]];
+export type OrFilter<TFilter> = ['or', ...(TFilter | LogicalFilter<TFilter>)[]];
+export type NotFilter<TFilter> = ['not', TFilter | LogicalFilter<TFilter>];
+export type NumberFilter<T extends number | Date> = T | ['gt' | 'lt' | 'gte' | 'lte', T];
+export type StringFilter<T extends string> =
+  | T
+  | ['gt' | 'lt' | 'gte' | 'lte', T]
+  | ['startsWith' | 'contains' | 'endsWith', string];
 export type Filters<T> =
   | OmitByValue<
       {
         readonly [K in keyof FieldsOf<T>]?: NonNullable<T[K]> extends boolean
-          ? T[K] | undefined
+          ? T[K]
           : NonNullable<T[K]> extends number | Date
-            ? T[K] | { readonly from?: T[K]; readonly until?: T[K] }
+            ? LogicalFilter<NumberFilter<NonNullable<T[K]>>> | NumberFilter<NonNullable<T[K]>>
             : NonNullable<T[K]> extends string
-              ?
-                  | T[K]
-                  | {
-                      readonly from?: T[K];
-                      readonly until?: T[K];
-                      readonly startsWith?: string;
-                      readonly contains?: string;
-                      readonly endsWith?: string;
-                    }
+              ? LogicalFilter<StringFilter<NonNullable<T[K]>>> | StringFilter<NonNullable<T[K]>>
               : never;
       },
       never

--- a/src/router-utils.test.ts
+++ b/src/router-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { defineRouter } from './router-utils.js';
+
+describe('router-utils', () => {
+  const add = jest.fn((params: { type: 'add'; a: number; b: number }) => params.a + params.b);
+  const subtract = jest.fn(
+    (params: { type: 'subtract'; c: number; d: number }) => params.c - params.d,
+  );
+  const handlers = { add, subtract };
+
+  test('router should call the correct handler based on typeKey', () => {
+    const router = defineRouter(handlers, 'type');
+
+    const addResult = router({ type: 'add', a: 1, b: 2 });
+    const subtractResult = router({ type: 'subtract', c: 1, d: 2 });
+
+    expect(addResult).toBe(3);
+    // Ensures that `add` was called with the correct parameters.
+    expect(add).toHaveBeenCalledWith({ type: 'add', a: 1, b: 2 });
+    // Ensures that `add` was called exactly once.
+    expect(add).toHaveBeenCalledTimes(1);
+
+    expect(subtractResult).toBe(-1);
+    expect(subtract).toHaveBeenCalledWith({ type: 'subtract', c: 1, d: 2 });
+    expect(subtract).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/router-utils.ts
+++ b/src/router-utils.ts
@@ -1,0 +1,43 @@
+/** @internal */
+type DefaultHandlers<TTypeKey extends string> = {
+  // biome-ignore lint/suspicious/noExplicitAny: 本当は`params`の型を`unknown & ...`にしたいが、`params`の制約を拡張できなくなってしまうので、`any & ...`にする。
+  readonly [K in string]: (this: unknown, params: any & { [TK in TTypeKey]: K }) => any;
+};
+
+/** @internal */
+type ParamsOfType<
+  K extends keyof THandlers,
+  THandlers extends DefaultHandlers<TTypeKey>,
+  TTypeKey extends string,
+> = Extract<
+  { [L in keyof THandlers]: Parameters<THandlers[L]>[0] }[keyof THandlers],
+  { [TK in TTypeKey]: K }
+>;
+
+/** @internal */
+type ReturnsOfType<
+  K extends keyof THandlers,
+  THandlers extends DefaultHandlers<TTypeKey>,
+  TTypeKey extends string,
+> = { [L in keyof THandlers]: ReturnType<THandlers[L]> }[K];
+
+export type Router<THandlers extends DefaultHandlers<TTypeKey>, TTypeKey extends string> = <
+  K extends keyof THandlers,
+>(
+  params: ParamsOfType<K, THandlers, TTypeKey>,
+) => ReturnsOfType<K, THandlers, TTypeKey>;
+
+/**
+ * Creates a router that dispatches to the appropriate handler based on the value of the specified `typeKey` property in the parameter.
+ *
+ * @param handlers A dictionary of handlers where each key corresponds to a type and each value is a function that handles that type.
+ * @param typeKey The key in the parameter object that determines which handler to call.
+ * @returns A router function that takes a parameter object and calls the appropriate handler based on the `typeKey` value of the object.
+ */
+export const defineRouter =
+  <THandlers extends DefaultHandlers<TTypeKey>, TTypeKey extends string>(
+    handlers: THandlers,
+    typeKey: TTypeKey,
+  ): Router<THandlers, TTypeKey> =>
+  (params) =>
+    handlers[params[typeKey]](params);

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,3 +1,5 @@
+import type { AbortableFunction } from './asyncify-events.js';
+
 /**
  * 指定された時間だけ待って解決する`Promise`を返す。
  * - `abortSignal`を指定していて、`abortSignal`に紐付いている`AbortController`で`abort`を呼び出した場合、返した`Promise`を拒否する。
@@ -57,3 +59,35 @@ export const executeAt = async <TFunc extends () => TReturned, TReturned>(params
   await sleep({ timeoutMs: date.getTime() - now.getTime(), abortSignal, timerResetIntervalMs });
   return func();
 };
+
+export type SchedulableFunction<TArgs extends unknown[], TReturned> = (
+  args: TArgs,
+  date: Date,
+  abortSignal?: AbortSignal,
+) => Promise<TReturned>;
+
+export const schedulableFunctionFromFunction = <
+  TFunc extends (this: unknown, ...args: TArgs) => TReturned,
+  TArgs extends unknown[] = Parameters<TFunc>,
+  TReturned = ReturnType<TFunc>,
+>(
+  func: TFunc,
+  timerResetIntervalMs?: number,
+): SchedulableFunction<TArgs, TReturned> => {
+  const abortableFunction = (args: TArgs) => func(...args);
+  return schedulableFunctionFromAbortableFunction(abortableFunction, timerResetIntervalMs);
+};
+
+export const schedulableFunctionFromAbortableFunction =
+  <
+    TFunc extends AbortableFunction<TArgs, TReturned>,
+    TArgs extends unknown[] = Parameters<TFunc>[0],
+    TReturned = ReturnType<TFunc>,
+  >(
+    func: TFunc,
+    timerResetIntervalMs?: number,
+  ): SchedulableFunction<TArgs, TReturned> =>
+  async (args, date, abortSignal) => {
+    await sleep({ timeoutMs: date.getTime() - Date.now(), abortSignal, timerResetIntervalMs });
+    return func(args, abortSignal);
+  };


### PR DESCRIPTION
clarify the usage of asyncify-events and execution-queue by providing functions instead of classes.

- rewrite asyncify-events with functions
- rewrite execution-queue and repository-utils
- add some utility functions (`defineRouter`, `dispatchFunctionFromEventTarget`, `subscribeHandlersToEventTarget`)