### PR TITLE
add: new testcases for test-execution-queue

### DIFF
--- a/src/execution-queue.test.ts
+++ b/src/execution-queue.test.ts
@@ -1,13 +1,14 @@
-import { beforeAll, describe, expect, jest, test } from '@jest/globals';
+import { afterEach } from 'node:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import {
-  type Cancel,
   type Enqueue,
   type Execution,
   type ExecutionId,
   type ExecutionRepository,
-  createCalculateExecutionDateFromTimeWindowRateLimitationRules,
-  executionQueue,
+  calculateExecutionDateFunctionFromTimeWindowRateLimitationRules,
+  executionQueueFrom,
 } from './execution-queue.js';
+import { generateId } from './random-values.js';
 import {
   type Filters,
   type FromRepository,
@@ -18,7 +19,7 @@ import { type SchedulableFunction, schedulableFunctionFromFunction } from './tim
 
 class ExecutionRepositoryMock<
   TFunc extends SchedulableFunction<TArgs, TReturned>,
-  TArgs extends never[] = Parameters<TFunc>[0],
+  TArgs extends unknown[] = Parameters<TFunc>[0],
   TReturned = Awaited<ReturnType<TFunc>>,
 > implements ExecutionRepository<TFunc, TArgs, TReturned>
 {
@@ -96,48 +97,50 @@ class ExecutionRepositoryMock<
   }
 }
 
-const expectedExecutionDateMap = new Map<number, Date>();
-const actualExecutionDateMap = new Map<number, Date>();
-const func = (id: number) => {
-  const actualExecutedDate = new Date();
-  actualExecutionDateMap.set(id, actualExecutedDate);
-  return actualExecutedDate;
-};
-const schedulableFunction = schedulableFunctionFromFunction(func);
-const executionRepository = new ExecutionRepositoryMock<SchedulableFunction<[number], Date>>();
-const executionQueueEventTarget = new EventTarget();
-
 const timeWindowRateLimitationRules = [
   { timeWindowMs: 5000, executionCountPerTimeWindow: 10 },
   { timeWindowMs: 10000, executionCountPerTimeWindow: 15 },
   { timeWindowMs: 20000, executionCountPerTimeWindow: 20 },
 ];
 
-let executionQueueGateway: { readonly enqueue: Enqueue<[number]>; readonly cancel: Cancel };
-
 beforeAll(async () => {
   jest.useFakeTimers();
   jest.spyOn(global, 'setTimeout');
   jest.spyOn(global, 'setInterval');
-
-  executionQueueGateway = await executionQueue({
-    schedulableFunction,
-    executionQueueEventTarget,
-    executionRepository,
-    calculateExecutionDate: createCalculateExecutionDateFromTimeWindowRateLimitationRules(
-      timeWindowRateLimitationRules,
-    ),
-  });
-
-  for (let i = 0; i < 100; i += 1) {
-    const { executedAt } = await executionQueueGateway.enqueue(i);
-    expectedExecutionDateMap.set(i, executedAt);
-  }
 });
 
-describe('ExecutionQueueWithTimeWindowRateLimitation', () => {
-  describe('enqueue()', () => {
-    test('Rate limitations are not exceeded', async () => {
+describe('execution-queue', () => {
+  describe('enqueue', () => {
+    const expectedExecutionDateMap = new Map<number, Date>();
+    const actualExecutionDateMap = new Map<number, Date>();
+    const func = (id: number) => {
+      const actualExecutedDate = new Date();
+      actualExecutionDateMap.set(id, actualExecutedDate);
+      return actualExecutedDate;
+    };
+    const schedulableFunction = schedulableFunctionFromFunction(func);
+    const executionRepository = new ExecutionRepositoryMock<SchedulableFunction<[number], Date>>();
+    let executionQueue: Awaited<ReturnType<typeof executionQueueFrom<typeof schedulableFunction>>>;
+
+    beforeAll(async () => {
+      executionQueue = await executionQueueFrom({
+        schedulableFunction,
+        calculateExecutionDate: calculateExecutionDateFunctionFromTimeWindowRateLimitationRules(
+          timeWindowRateLimitationRules,
+        ),
+        executionQueueEventTarget: new EventTarget(),
+        executionRepository,
+      });
+
+      for (let i = 0; i < 100; i += 1) {
+        const { executedAt } = await executionQueue.enqueue(i);
+        expectedExecutionDateMap.set(i, executedAt);
+      }
+
+      await jest.advanceTimersByTimeAsync(100000);
+    });
+
+    test('rate limitations should not be exceeded', async () => {
       const executions = await executionRepository.getMany({
         orderBy: { executedAt: 'asc' },
       });
@@ -155,19 +158,264 @@ describe('ExecutionQueueWithTimeWindowRateLimitation', () => {
       }
     });
 
-    test('Enqueued executions are executed on time', async () => {
-      await jest.advanceTimersByTimeAsync(100000);
+    test('enqueued executions should be executed on time', async () => {
       [...expectedExecutionDateMap.entries()].map(([id, expectedExecutionDate]) => {
-        const actualExecutedDate = actualExecutionDateMap.get(id);
-        expect(actualExecutedDate?.getTime()).toBeDefined();
-        if (actualExecutedDate?.getTime() === undefined) {
-          return;
+        const actualExecutionDate = actualExecutionDateMap.get(id);
+        expect(actualExecutionDate?.getTime()).toBeDefined();
+        if (actualExecutionDate?.getTime() === undefined) {
+          throw Error(`Execution date for ID ${id} is undefined`);
         }
         expect(
-          Math.abs(actualExecutedDate?.getTime() - expectedExecutionDate.getTime()),
+          Math.abs(actualExecutionDate?.getTime() - expectedExecutionDate.getTime()),
         ).toBeLessThanOrEqual(1);
       });
       expect(await executionRepository.count({ filters: { status: 'completed' } })).toEqual(100);
+    });
+  });
+
+  describe('cancel', () => {
+    const returnedValues: number[] = [];
+    const executionIds: Awaited<ReturnType<Enqueue<[number]>>>[] = [];
+    const func = jest.fn((id: number) => {
+      returnedValues.push(id);
+    });
+    const schedulableFunction = schedulableFunctionFromFunction(func);
+    const executionQueueEventTarget = new EventTarget();
+    let executionQueue: Awaited<ReturnType<typeof executionQueueFrom<typeof schedulableFunction>>>;
+
+    beforeAll(async () => {
+      executionQueue = await executionQueueFrom<typeof schedulableFunction>({
+        schedulableFunction,
+        calculateExecutionDate: calculateExecutionDateFunctionFromTimeWindowRateLimitationRules(
+          timeWindowRateLimitationRules,
+        ),
+        executionQueueEventTarget,
+        executionRepository: new ExecutionRepositoryMock(),
+      });
+    });
+
+    test('canceled executions should not be executed', async () => {
+      for (let i = 0; i < 100; i += 1) {
+        const returned = await executionQueue.enqueue(i);
+        executionIds.push(returned);
+      }
+      await jest.advanceTimersByTimeAsync(45500);
+      for (let i = 50; i < 100; i += 1) {
+        executionQueue.cancel(executionIds[i].executionId);
+      }
+      await jest.advanceTimersByTimeAsync(50000);
+
+      for (let i = 0; i < 50; i += 1) {
+        expect(func).toHaveBeenCalledWith(i);
+      }
+      for (let i = 50; i < 100; i += 1) {
+        expect(func).not.toHaveBeenCalledWith(i);
+      }
+    });
+  });
+
+  describe('execution queue event', () => {
+    const schedulableFunction = jest.fn(
+      schedulableFunctionFromFunction((id: number, shouldFail: boolean) => {
+        if (shouldFail) {
+          throw new Error(id.toString());
+        }
+        return id;
+      }),
+    );
+    const executionQueueEventTarget = new EventTarget();
+    let executionQueue: Awaited<ReturnType<typeof executionQueueFrom<typeof schedulableFunction>>>;
+    let executionQueueWithDelayedInitialization: Awaited<
+      ReturnType<typeof executionQueueFrom<typeof schedulableFunction>>
+    >;
+    const startedHandler = jest.fn();
+    const completedHandler = jest.fn();
+    const failedHandler = jest.fn();
+    const scheduleUpdatedHandler = jest.fn();
+
+    beforeAll(() => {
+      executionQueueEventTarget.addEventListener('started', startedHandler);
+      executionQueueEventTarget.addEventListener('completed', completedHandler);
+      executionQueueEventTarget.addEventListener('failed', failedHandler);
+      executionQueueEventTarget.addEventListener('scheduleUpdated', scheduleUpdatedHandler);
+    });
+
+    beforeEach(async () => {
+      executionQueue = await executionQueueFrom({
+        schedulableFunction: schedulableFunction,
+        calculateExecutionDate: calculateExecutionDateFunctionFromTimeWindowRateLimitationRules(
+          timeWindowRateLimitationRules,
+        ),
+        executionQueueEventTarget,
+        executionRepository: new ExecutionRepositoryMock(),
+      });
+    });
+
+    test('queue should dispatch ExecutionQueueStartedEvent and ExecutionQueueCompletedEvent', async () => {
+      const { executionId } = await executionQueue.enqueue(1, false);
+      await jest.advanceTimersByTimeAsync(1);
+
+      expect(startedHandler).toHaveBeenCalledTimes(1);
+      expect(startedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'started',
+          detail: expect.objectContaining({
+            type: 'started',
+            executionId,
+            args: expect.arrayContaining([1, false]),
+          }),
+        }),
+      );
+      expect(completedHandler).toHaveBeenCalledTimes(1);
+      expect(completedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'completed',
+          detail: expect.objectContaining({
+            type: 'completed',
+            executionId,
+            args: expect.arrayContaining([1, false]),
+            value: 1,
+          }),
+        }),
+      );
+    });
+
+    test('queue should dispatch ExecutionQueueFailedEvent', async () => {
+      const { executionId } = await executionQueue.enqueue(1, true);
+      await jest.advanceTimersByTimeAsync(1);
+
+      expect(completedHandler).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'failed',
+          detail: expect.objectContaining({ executionId }),
+        }),
+      );
+      expect(failedHandler).toHaveBeenCalledTimes(1);
+      expect(failedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'failed',
+          detail: expect.objectContaining({
+            type: 'failed',
+            executionId,
+            args: expect.arrayContaining([1, true]),
+            value: expect.objectContaining({ message: '1' }),
+          }),
+        }),
+      );
+    });
+
+    test('queue should dispatch ExecutionQueuescheduleUpdatedEvent', async () => {
+      const executionRepository = new ExecutionRepositoryMock<typeof schedulableFunction>();
+      const executionId = generateId() as ExecutionId;
+      const executedAt = new Date();
+      executionRepository.createOne({
+        id: executionId,
+        args: [1, false],
+        executedAt,
+        status: 'pending',
+      });
+      await jest.advanceTimersByTimeAsync(10000);
+
+      executionQueueWithDelayedInitialization = await executionQueueFrom({
+        schedulableFunction: schedulableFunction,
+        calculateExecutionDate: calculateExecutionDateFunctionFromTimeWindowRateLimitationRules(
+          timeWindowRateLimitationRules,
+        ),
+        executionQueueEventTarget,
+        executionRepository,
+      });
+
+      expect(scheduleUpdatedHandler).toHaveBeenCalledTimes(1);
+      expect(scheduleUpdatedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'scheduleUpdated',
+          detail: expect.objectContaining({
+            type: 'scheduleUpdated',
+            executionId,
+            args: expect.arrayContaining([1]),
+            previousExecutedAt: executedAt,
+            newExecutedAt: expect.any(Date),
+          }),
+        }),
+      );
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+      executionQueueEventTarget.removeEventListener('started', startedHandler);
+      executionQueueEventTarget.removeEventListener('completed', completedHandler);
+      executionQueueEventTarget.removeEventListener('failed', failedHandler);
+      executionQueueEventTarget.removeEventListener('scheduleUpdated', scheduleUpdatedHandler);
+    });
+  });
+
+  describe('association with ExecutionRepository', () => {
+    const schedulableFunction = schedulableFunctionFromFunction(
+      (id: number, shouldFail: boolean) =>
+        new Promise<number>((resolve, reject) => {
+          setTimeout(() => {
+            if (shouldFail) {
+              reject(new Error(id.toString()));
+              return;
+            }
+            resolve(id);
+          }, 1000);
+        }),
+    );
+    let executionQueue: Awaited<ReturnType<typeof executionQueueFrom<typeof schedulableFunction>>>;
+    const executionRepository = new ExecutionRepositoryMock<typeof schedulableFunction>();
+
+    beforeEach(async () => {
+      executionQueue = await executionQueueFrom<typeof schedulableFunction>({
+        schedulableFunction,
+        calculateExecutionDate: calculateExecutionDateFunctionFromTimeWindowRateLimitationRules(
+          timeWindowRateLimitationRules,
+        ),
+        executionQueueEventTarget: new EventTarget(),
+        executionRepository,
+      });
+    });
+
+    test('execution queue should create an execution in the repository when enqueued', async () => {
+      const { executionId } = await executionQueue.enqueue(1, false);
+      const execution = await executionRepository.getOneById(executionId);
+
+      expect(execution).toBeDefined();
+      expect(execution?.args).toEqual([1, false]);
+      expect(execution?.status).toEqual('pending');
+    });
+
+    test('execution queue should update the execution in the repository when completed', async () => {
+      const { executionId } = await executionQueue.enqueue(1, false);
+
+      await jest.advanceTimersByTimeAsync(500);
+      const executionRunning = await executionRepository.getOneById(executionId);
+
+      expect(executionRunning).toBeDefined();
+      expect(executionRunning?.args).toEqual([1, false]);
+      expect(executionRunning?.status).toEqual('running');
+
+      await jest.advanceTimersByTimeAsync(1000);
+      const executionCompleted = await executionRepository.getOneById(executionId);
+
+      expect(executionCompleted).toBeDefined();
+      expect(executionCompleted?.args).toEqual([1, false]);
+      expect(executionCompleted?.status).toEqual('completed');
+    });
+
+    test('execution queue should update the execution in the repository when failed', async () => {
+      const { executionId } = await executionQueue.enqueue(1, true);
+      await executionQueue.cancel(executionId);
+      await jest.advanceTimersByTimeAsync(1000);
+
+      const execution = await executionRepository.getOneById(executionId);
+
+      expect(execution).toBeDefined();
+      expect(execution?.args).toEqual([1, true]);
+      expect(execution?.status).toEqual('failed');
     });
   });
 });

--- a/src/execution-queue.ts
+++ b/src/execution-queue.ts
@@ -110,7 +110,6 @@ export type ExecutionRepository<
   updateOne(this: unknown, execution: FromRepository<Execution<TArgs>>): Promise<void>;
   deleteOneById(this: unknown, executionId: ExecutionId): Promise<void>;
 };
-//#endregion
 
 type StateValue<TArgs extends unknown[]> =
   | {
@@ -133,7 +132,7 @@ type ControlRunEventData<TArgs extends unknown[]> = {
 type ControlSuspendEventData = { readonly type: 'suspend' };
 //#endregion
 
-export const executionQueue = async <
+export const executionQueueFrom = async <
   TFunc extends SchedulableFunction<TArgs, TReturned>,
   TArgs extends unknown[] = Parameters<TFunc>[0],
   TReturned = Awaited<ReturnType<TFunc>>,
@@ -297,7 +296,7 @@ export const executionQueue = async <
   };
 };
 
-export const createCalculateExecutionDateFromTimeWindowRateLimitationRules =
+export const calculateExecutionDateFunctionFromTimeWindowRateLimitationRules =
   (rules: readonly TimeWindowRateLimitationRule[]): CalculateExecutionDate =>
   async (repository) =>
     calculateNextExecutionDate({

--- a/src/execution-queue.ts
+++ b/src/execution-queue.ts
@@ -19,7 +19,7 @@ export type Execution<TArgs extends unknown[]> = {
   readonly id: ExecutionId;
   readonly args: TArgs;
   readonly executedAt: Date;
-  readonly status: 'pending' | 'canceled' | 'running' | 'completed' | 'failed';
+  readonly status: 'pending' | 'running' | 'completed' | 'failed';
 };
 
 export type Enqueue<TArgs extends unknown[]> = (

--- a/src/execution-queue.ts
+++ b/src/execution-queue.ts
@@ -131,6 +131,7 @@ type ControlRunEventData<TArgs extends unknown[]> = {
   readonly abortController: AbortController;
 };
 type ControlSuspendEventData = { readonly type: 'suspend' };
+//#endregion
 
 export const executionQueue = async <
   TFunc extends SchedulableFunction<TArgs, TReturned>,

--- a/src/execution-queue.ts
+++ b/src/execution-queue.ts
@@ -209,6 +209,11 @@ export const executionQueue = async <
     }
   };
   const handlePop = async () => {
+    if (queueState.get().status === 'running') {
+      // すでに実行中の場合は、何もしない。
+      return;
+    }
+
     try {
       // 次の実行待ちを取り出す。
       const [nextExecution] = await params.executionRepository.getMany({

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -73,7 +73,7 @@ export const schedulableFunctionFromFunction = <
 >(
   func: TFunc,
   timerResetIntervalMs?: number,
-): SchedulableFunction<TArgs, TReturned> => {
+): SchedulableFunction<TArgs, Awaited<TReturned>> => {
   const abortableFunction = (args: TArgs) => func(...args);
   return schedulableFunctionFromAbortableFunction(abortableFunction, timerResetIntervalMs);
 };
@@ -86,8 +86,9 @@ export const schedulableFunctionFromAbortableFunction =
   >(
     func: TFunc,
     timerResetIntervalMs?: number,
-  ): SchedulableFunction<TArgs, TReturned> =>
-  async (args, date, abortSignal) => {
+  ): SchedulableFunction<TArgs, Awaited<TReturned>> =>
+  async (args, date, abortSignal): Promise<Awaited<TReturned>> => {
     await sleep({ timeoutMs: date.getTime() - Date.now(), abortSignal, timerResetIntervalMs });
-    return func(args, abortSignal);
+    const returned = await func(args, abortSignal);
+    return returned;
   };


### PR DESCRIPTION
### What's changed

- add test cases for ExecutionQueueEvent
- add test cases for ExecutionRepository association

#### Fixes

- fix broken return type of scheduledFunctionFromFunction
- fix: popping queue should be postponed when an execution is running