### PR TITLE
fix: add ".js" extension to import specifiers

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,18 @@
+{
+  "lsp": {
+    "vtsls": {
+      "settings": {
+        "javascript": {
+          "preferences": {
+            "importModuleSpecifierEnding": "js"
+          }
+        },
+        "typescript": {
+          "preferences": {
+            "importModuleSpecifierEnding": "js"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/asyncify-events.ts
+++ b/src/asyncify-events.ts
@@ -1,4 +1,4 @@
-import type { NominalPrimitive } from './nominal-primitive.type';
+import type { NominalPrimitive } from './nominal-primitive.type.js';
 import { generateId, type Id } from './random-values.js';
 import { defineRouter } from './router-utils.js';
 

--- a/src/cached-function.test.ts
+++ b/src/cached-function.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, jest, test } from '@jest/globals';
-import { cachedFunctionFrom, LruCacheStrategy } from './cached-function';
+import { cachedFunctionFrom, LruCacheStrategy } from './cached-function.js';
 
 const func = (a: number): number => {
   return a ** a;

--- a/src/cached-function.ts
+++ b/src/cached-function.ts
@@ -1,8 +1,8 @@
 import {
   LinkedTotalOrderedMap,
   type TotalOrderedMap,
-} from './total-ordered-map';
-import { TupleKeyedMap } from './tuple-keyed-map';
+} from './total-ordered-map.js';
+import { TupleKeyedMap } from './tuple-keyed-map.js';
 
 export const cachedFunctionFrom = <A extends unknown[], R>(
   func: (this: unknown, ...args: A) => R,
@@ -81,54 +81,57 @@ const calculateKeyFactory = <A extends unknown[]>(
   };
 };
 
-class WithCacheStrategy<K, V> implements Map<K, V> {
-  private readonly strategy: CacheStrategy<K, V>;
-  private readonly baseMap: Map<K, V>;
+const strategy = Symbol('strategy');
+const baseMap = Symbol('baseMap');
 
-  constructor(baseMap: Map<K, V>, strategy: CacheStrategy<K, V>) {
-    this.strategy = strategy;
-    this.baseMap = baseMap;
+class WithCacheStrategy<K, V> implements Map<K, V> {
+  private readonly [strategy]: CacheStrategy<K, V>;
+  private readonly [baseMap]: Map<K, V>;
+
+  constructor(map: Map<K, V>, cacheStrategy: CacheStrategy<K, V>) {
+    this[strategy] = cacheStrategy;
+    this[baseMap] = map;
   }
   clear(): void {
-    this.strategy.clear();
-    this.baseMap.clear();
+    this[strategy].clear();
+    this[baseMap].clear();
   }
   delete(key: K): boolean {
-    this.strategy.delete(key);
-    return this.baseMap.delete(key);
+    this[strategy].delete(key);
+    return this[baseMap].delete(key);
   }
   forEach(
     callbackfn: (value: V, key: K, map: Map<K, V>) => void,
     thisArg?: unknown,
   ): void {
-    this.baseMap.forEach(callbackfn, thisArg);
+    this[baseMap].forEach(callbackfn, thisArg);
   }
   get(key: K): V | undefined {
-    this.strategy.touch(key, this.baseMap);
-    return this.baseMap.get(key);
+    this[strategy].touch(key, this[baseMap]);
+    return this[baseMap].get(key);
   }
   has(key: K): boolean {
-    return this.baseMap.has(key);
+    return this[baseMap].has(key);
   }
   set(key: K, value: V): this {
-    this.strategy.touch(key, this.baseMap);
-    this.baseMap.set(key, value);
+    this[strategy].touch(key, this[baseMap]);
+    this[baseMap].set(key, value);
     return this;
   }
   get size(): number {
-    return this.baseMap.size;
+    return this[baseMap].size;
   }
   entries(): MapIterator<[K, V]> {
-    return this.baseMap.entries();
+    return this[baseMap].entries();
   }
   keys(): MapIterator<K> {
-    return this.baseMap.keys();
+    return this[baseMap].keys();
   }
   values(): MapIterator<V> {
-    return this.baseMap.values();
+    return this[baseMap].values();
   }
   [Symbol.iterator](): MapIterator<[K, V]> {
-    return this.baseMap[Symbol.iterator]();
+    return this[baseMap][Symbol.iterator]();
   }
   get [Symbol.toStringTag]() {
     return 'MapWithCacheStrategy';

--- a/src/date-time.ts
+++ b/src/date-time.ts
@@ -1,4 +1,4 @@
-import type { NominalPrimitive } from './nominal-primitive.type';
+import type { NominalPrimitive } from './nominal-primitive.type.js';
 
 const unixTimeTypeSymbol = Symbol('UnixTime');
 

--- a/src/random-values.ts
+++ b/src/random-values.ts
@@ -1,4 +1,4 @@
-import type { NominalPrimitive } from './nominal-primitive.type';
+import type { NominalPrimitive } from './nominal-primitive.type.js';
 
 /**
  * エンティティ`E`のID文字列を表す公称プリミティブ型。

--- a/src/repository-utils.ts
+++ b/src/repository-utils.ts
@@ -1,4 +1,4 @@
-import type { FieldsOf, OmitByValue, PickByValue } from './utils.type';
+import type { FieldsOf, OmitByValue, PickByValue } from './utils.type.js';
 
 const latestVersion = Symbol('repository.latestVersion');
 

--- a/src/total-ordered-map.test.ts
+++ b/src/total-ordered-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { LinkedTotalOrderedMap } from './total-ordered-map';
+import { LinkedTotalOrderedMap } from './total-ordered-map.js';
 
 const toArrayValues = <T>(m: LinkedTotalOrderedMap<T>) =>
   Array.from(m.values());

--- a/src/tuple-keyed-map.performance-test.ts
+++ b/src/tuple-keyed-map.performance-test.ts
@@ -1,5 +1,5 @@
 import { argv, memoryUsage } from 'node:process';
-import { TupleKeyedMap } from './tuple-keyed-map';
+import { TupleKeyedMap } from './tuple-keyed-map.js';
 
 const COUNT = 100_000;
 const MAX_TUPLE_LENGTH = 1;

--- a/src/tuple-keyed-map.test.ts
+++ b/src/tuple-keyed-map.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
-import { TupleKeyedMap } from './tuple-keyed-map';
-import { StringifiedTupleKeyedMap } from './tuple-keyed-map.performance-test';
+import { TupleKeyedMap } from './tuple-keyed-map.js';
+import { StringifiedTupleKeyedMap } from './tuple-keyed-map.performance-test.js';
 
 describe('TupleKeyedMap', () => {
   test('set() with new key should inserts new entry', () => {

--- a/src/tuple-keyed-map.ts
+++ b/src/tuple-keyed-map.ts
@@ -1,4 +1,4 @@
-import { LinkedTotalOrderedMap } from './total-ordered-map';
+import { LinkedTotalOrderedMap } from './total-ordered-map.js';
 
 const root = Symbol('root');
 const nodes = Symbol('nodes');

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
+    "./*.config.js",
+    "./*.config.cjs",
     "./src/**/*.test.ts",
     "./src/**/*.test.tsx",
     "./src/**/*.performance-test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,28 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["DOM", "WebWorker"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
     "jsx": "react-jsx",
-    "module": "ESNext",
-    "moduleResolution": "node10",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
     "outDir": "./esmodules",
+
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+
     "strict": true,
+    "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,
-    "skipLibCheck": true
+    "verbatimModuleSyntax": true,
+    // "checkJs": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    // "noUncheckedIndexedAccess": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false
   },
   "include": ["./src/**/*", "./scripts/**/*", "./*.config.js", "./*.config.cjs"]
 }


### PR DESCRIPTION
### What's changed

- add ".js" extension to import specifiers
- Configure Zed to add ".js" extension on auto import